### PR TITLE
Explaining the return in case of exception.

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/encoding/FeignContentGzipEncodingInterceptor.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/encoding/FeignContentGzipEncodingInterceptor.java
@@ -79,9 +79,8 @@ public class FeignContentGzipEncodingInterceptor extends BaseRequestInterceptor 
 			final long length = Long.parseLong(strLen);
 			return length > getProperties().getMinRequestSize();
 		} catch (NumberFormatException ex) {
-			// ignores the exception
+			return false;
 		}
-		return false;
 	}
 
 	/**


### PR DESCRIPTION
Explaining the return in case of an exception.
To get to the return at the end of the method is only for this case. 
Thus avoiding an ignored exception.