### PR TITLE
Support to set loadBalancerKey

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/ribbon/CachingSpringLoadBalancerFactory.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/ribbon/CachingSpringLoadBalancerFactory.java
@@ -36,8 +36,8 @@ import com.netflix.loadbalancer.ILoadBalancer;
  */
 public class CachingSpringLoadBalancerFactory {
 
-	private final SpringClientFactory factory;
-	private LoadBalancedRetryFactory loadBalancedRetryFactory = null;
+	protected final SpringClientFactory factory;
+	protected LoadBalancedRetryFactory loadBalancedRetryFactory = null;
 
 	private volatile Map<String, FeignLoadBalancer> cache = new ConcurrentReferenceHashMap<>();
 

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/ribbon/FeignLoadBalancer.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/ribbon/FeignLoadBalancer.java
@@ -118,7 +118,7 @@ public class FeignLoadBalancer extends
 		private final Request request;
 		private final Client client;
 
-		RibbonRequest(Client client, Request request, URI uri) {
+		protected RibbonRequest(Client client, Request request, URI uri) {
 			this.client = client;
 			setUri(uri);
 			this.request = toRequest(request);
@@ -170,6 +170,13 @@ public class FeignLoadBalancer extends
 			};
 		}
 
+		public Request getRequest() {
+			return request;
+		}
+
+		public Client getClient() {
+			return client;
+		}
 
 		@Override
 		public Object clone() {
@@ -182,7 +189,7 @@ public class FeignLoadBalancer extends
 		private final URI uri;
 		private final Response response;
 
-		RibbonResponse(URI uri, Response response) {
+		protected RibbonResponse(URI uri, Response response) {
 			this.uri = uri;
 			this.response = response;
 		}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignLoadBalancerTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignLoadBalancerTests.java
@@ -21,8 +21,10 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import com.netflix.loadbalancer.reactive.LoadBalancerCommand;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -166,6 +168,59 @@ public class FeignLoadBalancerTests {
 
 		assertThat(cloneRequest.url(),is(url));
 
+	}
+
+	@Test
+	public void testOverrideFeignLoadBalancer() throws Exception {
+		when(this.config.get(IsSecure)).thenReturn(false);
+		Server server1 = new Server("foo", 6666);
+		Server server2 = new Server("foo", 7777);
+
+		this.feignLoadBalancer = new FeignLoadBalancer(new ILoadBalancer() {
+			@Override
+			public void addServers(List<Server> list) {
+
+			}
+
+			@Override
+			public Server chooseServer(Object loadBalancerKey) {
+				return loadBalancerKey == null ? server2 : server1;
+			}
+
+			@Override
+			public void markServerDown(Server server) {
+
+			}
+
+			@Override
+			public List<Server> getServerList(boolean b) {
+				return null;
+			}
+
+			@Override
+			public List<Server> getReachableServers() {
+				return null;
+			}
+
+			@Override
+			public List<Server> getAllServers() {
+				return null;
+			}
+		}, this.config,
+				this.inspector) {
+			protected void customizeLoadBalancerCommandBuilder(final FeignLoadBalancer.RibbonRequest request, final IClientConfig config,
+															   final LoadBalancerCommand.Builder<FeignLoadBalancer.RibbonResponse> builder) {
+				builder.withServerLocator(request.getRequest().headers().get("c_ip"));
+			}
+		};
+		Request request = new RequestTemplate().method("GET").request();
+		RibbonResponse resp = this.feignLoadBalancer.executeWithLoadBalancer(new RibbonRequest(this.delegate, request,
+				new URI(request.url())), null);
+		assertThat(resp.getRequestedURI().getPort(), is(7777));
+		request = new RequestTemplate().method("GET").header("c_ip", "666").request();
+		resp = this.feignLoadBalancer.executeWithLoadBalancer(new RibbonRequest(this.delegate, request,
+				new URI(request.url())), null);
+		assertThat(resp.getRequestedURI().getPort(), is(6666));
 	}
 
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignLoadBalancerTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignLoadBalancerTests.java
@@ -21,9 +21,10 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
+import com.netflix.loadbalancer.BaseLoadBalancer;
+import com.netflix.loadbalancer.RoundRobinRule;
 import com.netflix.loadbalancer.reactive.LoadBalancerCommand;
 import org.junit.Before;
 import org.junit.Test;
@@ -175,38 +176,15 @@ public class FeignLoadBalancerTests {
 		when(this.config.get(IsSecure)).thenReturn(false);
 		Server server1 = new Server("foo", 6666);
 		Server server2 = new Server("foo", 7777);
-
-		this.feignLoadBalancer = new FeignLoadBalancer(new ILoadBalancer() {
+		BaseLoadBalancer baseLoadBalancer = new BaseLoadBalancer();
+		baseLoadBalancer.setRule(new RoundRobinRule() {
 			@Override
-			public void addServers(List<Server> list) {
-
-			}
-
-			@Override
-			public Server chooseServer(Object loadBalancerKey) {
+			public Server choose(Object loadBalancerKey) {
 				return loadBalancerKey == null ? server2 : server1;
 			}
+		});
 
-			@Override
-			public void markServerDown(Server server) {
-
-			}
-
-			@Override
-			public List<Server> getServerList(boolean b) {
-				return null;
-			}
-
-			@Override
-			public List<Server> getReachableServers() {
-				return null;
-			}
-
-			@Override
-			public List<Server> getAllServers() {
-				return null;
-			}
-		}, this.config,
+		this.feignLoadBalancer = new FeignLoadBalancer(baseLoadBalancer, this.config,
 				this.inspector) {
 			protected void customizeLoadBalancerCommandBuilder(final FeignLoadBalancer.RibbonRequest request, final IClientConfig config,
 															   final LoadBalancerCommand.Builder<FeignLoadBalancer.RibbonResponse> builder) {


### PR DESCRIPTION
Support to override CachingSpringLoadBalancerFactory to customize the FeignLoadBalancer instance.
use example:
```
@Configuration
public class FeignClientConfiguration {

    @Bean
    @Primary
    public Client feignClient(SpringClientFactory clientFactory, @Autowired(required = false) LoadBalancedRetryFactory retryFactory) {
        return new LoadBalancerFeignClient(new Client.Default(null, null),
                new CustomCachingSpringLoadBalancerFactory(clientFactory, retryFactory), clientFactory);
    }

    class CustomCachingSpringLoadBalancerFactory extends CachingSpringLoadBalancerFactory {

        private volatile Map<String, FeignLoadBalancer> cache = new ConcurrentReferenceHashMap<>();

        public CustomCachingSpringLoadBalancerFactory(SpringClientFactory factory) {
            super(factory);
        }

        public CustomCachingSpringLoadBalancerFactory(SpringClientFactory factory, LoadBalancedRetryFactory loadBalancedRetryPolicyFactory) {
            super(factory, loadBalancedRetryPolicyFactory);
        }

        @Override
        public FeignLoadBalancer create(String clientName) {
            FeignLoadBalancer client = this.cache.get(clientName);
            if(client != null) {
                return client;
            }
            IClientConfig config = this.factory.getClientConfig(clientName);
            ILoadBalancer lb = this.factory.getLoadBalancer(clientName);
            ServerIntrospector serverIntrospector = this.factory.getInstance(clientName, ServerIntrospector.class);
            client = loadBalancedRetryFactory != null ? new RetryableFeignLoadBalancer(lb, config, serverIntrospector,
                    loadBalancedRetryFactory) {
                protected void customizeLoadBalancerCommandBuilder(final FeignLoadBalancer.RibbonRequest request, final IClientConfig config,
                                                                   final LoadBalancerCommand.Builder<FeignLoadBalancer.RibbonResponse> builder) {
                    builder.withServerLocator(request.getRequest().headers().get(Constants.HEADER_CLIENT_IP));
                }
            } : new FeignLoadBalancer(lb, config, serverIntrospector) {
                protected void customizeLoadBalancerCommandBuilder(final FeignLoadBalancer.RibbonRequest request, final IClientConfig config,
                                                                   final LoadBalancerCommand.Builder<FeignLoadBalancer.RibbonResponse> builder) {
                    builder.withServerLocator(request.getRequest().headers().get(Constants.HEADER_CLIENT_IP));
                }
            };
            this.cache.put(clientName, client);
            return client;
        }

    }

}
```