### PR TITLE
Added support for MultipartFile

### DIFF
--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 	</parent>
 	<artifactId>spring-cloud-openfeign-docs</artifactId>
 	<packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>2.0.2.BUILD-SNAPSHOT</version>
+	<version>2.1.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<scm>
@@ -22,8 +22,8 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.7.3</jackson.version>
-		<spring-cloud-commons.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
-		<spring-cloud-netflix.version>2.0.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
+		<spring-cloud-commons.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-netflix.version>2.1.0.BUILD-SNAPSHOT</spring-cloud-netflix.version>
 
 		<!-- Plugin versions -->
 		<maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>spring-cloud-openfeign-core</artifactId>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -94,6 +94,11 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>io.github.openfeign.form</groupId>
+			<artifactId>feign-form-spring</artifactId>
+			<optional>true</optional>
+		</dependency>
+		<dependency>
 			<groupId>io.github.openfeign</groupId>
 			<artifactId>feign-slf4j</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -18,6 +18,7 @@ package org.springframework.cloud.openfeign.support;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,9 +36,11 @@ import org.springframework.cloud.openfeign.annotation.RequestParamParameterProce
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.ResourceLoaderAware;
 import org.springframework.core.DefaultParameterNameDiscoverer;
+import org.springframework.core.MethodParameter;
 import org.springframework.core.ParameterNameDiscoverer;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.TypeDescriptor;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.io.DefaultResourceLoader;
 import org.springframework.core.io.ResourceLoader;
@@ -58,6 +61,7 @@ import feign.Param;
 /**
  * @author Spencer Gibb
  * @author Abhijit Sarkar
+ * @author Halvdan Hoem Grelland
  */
 public class SpringMvcContract extends Contract.BaseContract
 		implements ResourceLoaderAware {
@@ -66,13 +70,18 @@ public class SpringMvcContract extends Contract.BaseContract
 
 	private static final String CONTENT_TYPE = "Content-Type";
 
+	private static final TypeDescriptor STRING_TYPE_DESCRIPTOR =
+			TypeDescriptor.valueOf(String.class);
+	private static final TypeDescriptor ITERABLE_TYPE_DESCRIPTOR =
+			TypeDescriptor.valueOf(Iterable.class);
+
 	private static final ParameterNameDiscoverer PARAMETER_NAME_DISCOVERER = new DefaultParameterNameDiscoverer();
 
 	private final Map<Class<? extends Annotation>, AnnotatedParameterProcessor> annotatedArgumentProcessors;
 	private final Map<String, Method> processedMethods = new HashMap<>();
 
 	private final ConversionService conversionService;
-	private final Param.Expander expander;
+	private final ConvertingExpanderFactory convertingExpanderFactory;
 	private ResourceLoader resourceLoader = new DefaultResourceLoader();
 
 	public SpringMvcContract() {
@@ -100,7 +109,7 @@ public class SpringMvcContract extends Contract.BaseContract
 		}
 		this.annotatedArgumentProcessors = toAnnotatedArgumentProcessorMap(processors);
 		this.conversionService = conversionService;
-		this.expander = new ConvertingExpander(conversionService);
+		this.convertingExpanderFactory = new ConvertingExpanderFactory(conversionService);
 	}
 
 	@Override
@@ -239,12 +248,38 @@ public class SpringMvcContract extends Contract.BaseContract
 						processParameterAnnotation, method);
 			}
 		}
-		if (isHttpAnnotation && data.indexToExpander().get(paramIndex) == null
-				&& this.conversionService.canConvert(
-						method.getParameterTypes()[paramIndex], String.class)) {
-			data.indexToExpander().put(paramIndex, this.expander);
+
+		if (isHttpAnnotation && data.indexToExpander().get(paramIndex) == null) {
+			TypeDescriptor typeDescriptor = createTypeDescriptor(method, paramIndex);
+			if (conversionService.canConvert(typeDescriptor, STRING_TYPE_DESCRIPTOR)) {
+				Param.Expander expander =
+						convertingExpanderFactory.getExpander(typeDescriptor);
+				if (expander != null) {
+					data.indexToExpander().put(paramIndex, expander);
+				}
+			}
 		}
 		return isHttpAnnotation;
+	}
+
+	private static TypeDescriptor createTypeDescriptor(Method method, int paramIndex) {
+		Parameter parameter = method.getParameters()[paramIndex];
+		MethodParameter methodParameter = MethodParameter.forParameter(parameter);
+		TypeDescriptor typeDescriptor = new TypeDescriptor(methodParameter);
+
+		// Feign applies the Param.Expander to each element of an Iterable, so in those
+		// cases we need to provide a TypeDescriptor of the element.
+		if (typeDescriptor.isAssignableTo(ITERABLE_TYPE_DESCRIPTOR)) {
+			TypeDescriptor elementTypeDescriptor =
+					typeDescriptor.getElementTypeDescriptor();
+
+			checkState(elementTypeDescriptor != null,
+					"Could not resolve element type of Iterable type %s. Not declared?",
+					typeDescriptor);
+
+			typeDescriptor = elementTypeDescriptor;
+		}
+		return typeDescriptor;
 	}
 
 	private void parseProduces(MethodMetadata md, Method method,
@@ -361,6 +396,10 @@ public class SpringMvcContract extends Contract.BaseContract
 		}
 	}
 
+	/**
+	 * @deprecated Not used internally anymore. Will be removed in the future.
+	 */
+	@Deprecated
 	public static class ConvertingExpander implements Param.Expander {
 
 		private final ConversionService conversionService;
@@ -374,5 +413,22 @@ public class SpringMvcContract extends Contract.BaseContract
 			return this.conversionService.convert(value, String.class);
 		}
 
+	}
+
+	private static class ConvertingExpanderFactory {
+
+		private final ConversionService conversionService;
+
+		ConvertingExpanderFactory(ConversionService conversionService) {
+			this.conversionService = conversionService;
+		}
+
+		Param.Expander getExpander(TypeDescriptor typeDescriptor) {
+			return value -> {
+				Object converted = this.conversionService.convert(
+						value, typeDescriptor, STRING_TYPE_DESCRIPTOR);
+				return (String) converted;
+			};
+		}
 	}
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientUsingPropertiesTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientUsingPropertiesTests.java
@@ -30,8 +30,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
@@ -144,6 +146,7 @@ public class FeignClientUsingPropertiesTests {
 	@Configuration
 	@EnableAutoConfiguration
 	@RestController
+	@Import(NoSecurityConfiguration.class)
 	protected static class Application {
 
 		@RequestMapping(method = RequestMethod.GET, value = "/foo")

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientConfigurationTests.java
@@ -28,6 +28,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.commons.httpclient.HttpClientConfiguration;
 import org.springframework.cloud.test.ClassPathExclusions;
@@ -49,8 +50,11 @@ public class FeignHttpClientConfigurationTests {
 
 	@Before
 	public void setUp() {
-		context = new SpringApplicationBuilder().properties("debug=true","feign.httpclient.disableSslValidation=true").web(false)
-				.sources(HttpClientConfiguration.class, FeignAutoConfiguration.class).run();
+		context = new SpringApplicationBuilder()
+				.properties("debug=true","feign.httpclient.disableSslValidation=true")
+				.web(WebApplicationType.NONE)
+				.sources(HttpClientConfiguration.class, FeignAutoConfiguration.class)
+				.run();
 	}
 
 	@After

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlTests.java
@@ -34,8 +34,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.util.ReflectionUtils;
@@ -103,6 +105,7 @@ public class FeignHttpClientUrlTests {
 	@EnableAutoConfiguration
 	@RestController
 	@EnableFeignClients(clients = { UrlClient.class, BeanUrlClient.class, BeanUrlClientNoProtocol.class })
+	@Import(NoSecurityConfiguration.class)
 	protected static class TestConfig {
 
 		@RequestMapping(method = RequestMethod.GET, value = "/hello")

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignOkHttpConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignOkHttpConfigurationTests.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.commons.httpclient.HttpClientConfiguration;
 import org.springframework.cloud.commons.httpclient.OkHttpClientFactory;
@@ -45,7 +46,7 @@ public class FeignOkHttpConfigurationTests {
 	@Before
 	public void setUp() {
 		context = new SpringApplicationBuilder().properties("debug=true","feign.httpclient.disableSslValidation=true",
-				"feign.okhttp.enabled=true", "feign.httpclient.enabled=false").web(false)
+				"feign.okhttp.enabled=true", "feign.httpclient.enabled=false").web(WebApplicationType.NONE)
 				.sources(HttpClientConfiguration.class, FeignAutoConfiguration.class).run();
 	}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/SpringDecoderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/SpringDecoderTests.java
@@ -28,7 +28,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -201,6 +203,7 @@ public class SpringDecoderTests extends FeignClientFactoryBean {
 	@Configuration
 	@EnableAutoConfiguration
 	@RestController
+	@Import(NoSecurityConfiguration.class)
 	protected static class Application implements TestClient {
 
 		@Override

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/SpringRetryDisabledTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/SpringRetryDisabledTests.java
@@ -22,6 +22,7 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerAutoConfiguration;
 import org.springframework.cloud.openfeign.ribbon.CachingSpringLoadBalancerFactory;
@@ -51,7 +52,7 @@ public class SpringRetryDisabledTests {
 
 	@Before
 	public void setUp() {
-		context = new SpringApplicationBuilder().web(false)
+		context = new SpringApplicationBuilder().web(WebApplicationType.NONE)
 				.sources(RibbonAutoConfiguration.class, LoadBalancerAutoConfiguration.class, RibbonClientConfiguration.class,
 						FeignRibbonClientAutoConfiguration.class).run();
 	}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignAcceptEncodingTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignAcceptEncodingTests.java
@@ -35,8 +35,10 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.encoding.app.client.InvoiceClient;
 import org.springframework.cloud.openfeign.encoding.app.domain.Invoice;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -76,6 +78,7 @@ public class FeignAcceptEncodingTests {
 	@EnableFeignClients(clients = InvoiceClient.class)
 	@RibbonClient(name = "local", configuration = LocalRibbonClientConfiguration.class)
 	@SpringBootApplication(scanBasePackages = "org.springframework.cloud.openfeign.encoding.app")
+	@Import(NoSecurityConfiguration.class)
 	public static class Application {
 	}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignContentEncodingTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignContentEncodingTests.java
@@ -33,8 +33,10 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.encoding.app.client.InvoiceClient;
 import org.springframework.cloud.openfeign.encoding.app.domain.Invoice;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -79,6 +81,7 @@ public class FeignContentEncodingTests {
 	@EnableFeignClients(clients = InvoiceClient.class)
 	@RibbonClient(name = "local", configuration = LocalRibbonClientConfiguration.class)
 	@SpringBootApplication(scanBasePackages = "org.springframework.cloud.openfeign.encoding.app")
+	@Import(NoSecurityConfiguration.class)
 	public static class Application {
 	}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/hystrix/security/HystrixSecurityApplication.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/hystrix/security/HystrixSecurityApplication.java
@@ -16,17 +16,45 @@
 
 package org.springframework.cloud.openfeign.hystrix.security;
 
-import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.hystrix.security.app.CustomConcurrenyStrategy;
+import org.springframework.cloud.openfeign.hystrix.security.app.ProxyUsernameController;
+import org.springframework.cloud.openfeign.hystrix.security.app.TestInterceptor;
 import org.springframework.cloud.openfeign.hystrix.security.app.UsernameClient;
+import org.springframework.cloud.openfeign.hystrix.security.app.UsernameController;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 
 /**
  * @author Daniel Lavoie
  */
 @Configuration
-@SpringBootApplication
+@EnableAutoConfiguration
 @EnableFeignClients(clients = UsernameClient.class)
+@Import(NoSecurityConfiguration.class)
 public class HystrixSecurityApplication {
+
+	@Bean
+	public CustomConcurrenyStrategy customConcurrenyStrategy() {
+		return new CustomConcurrenyStrategy();
+	}
+
+	@Bean
+	public TestInterceptor testInterceptor() {
+		return new TestInterceptor();
+	}
+
+	@Bean
+	public ProxyUsernameController proxyUsernameController() {
+		return new ProxyUsernameController();
+	}
+
+	@Bean
+	public UsernameController usernameController() {
+		return new UsernameController();
+	}
 
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/hystrix/security/app/CustomConcurrenyStrategy.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/hystrix/security/app/CustomConcurrenyStrategy.java
@@ -1,10 +1,9 @@
 package org.springframework.cloud.openfeign.hystrix.security.app;
 
-import java.util.concurrent.Callable;
-import org.springframework.stereotype.Component;
 import com.netflix.hystrix.strategy.concurrency.HystrixConcurrencyStrategy;
 
-@Component
+import java.util.concurrent.Callable;
+
 public class CustomConcurrenyStrategy extends HystrixConcurrencyStrategy {
 	private boolean hookCalled;
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/hystrix/security/app/TestInterceptor.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/hystrix/security/app/TestInterceptor.java
@@ -28,7 +28,6 @@ import org.springframework.stereotype.Component;
  * 
  * @author Daniel Lavoie
  */
-@Component
 public class TestInterceptor implements RequestInterceptor {
 
 	@Override

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/hystrix/security/app/UsernameClient.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/hystrix/security/app/UsernameClient.java
@@ -26,5 +26,5 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public interface UsernameClient {
 
 	@RequestMapping("/username")
-	public String getUsername();
+	String getUsername();
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignRibbonClientPathTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignRibbonClientPathTests.java
@@ -26,12 +26,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -84,16 +87,16 @@ public class FeignRibbonClientPathTests {
 	@FeignClient(name = "localapp", path = "/base/path")
 	protected interface TestClient1 extends TestClient { }
 
-	@FeignClient(name = "localapp", path = "base/path")
+	@FeignClient(name = "localapp1", path = "base/path")
 	protected interface TestClient2 extends TestClient { }
 
-	@FeignClient(name = "localapp", path = "base/path/")
+	@FeignClient(name = "localapp2", path = "base/path/")
 	protected interface TestClient3 extends TestClient { }
 
-	@FeignClient(name = "localapp", path = "/base/path/")
+	@FeignClient(name = "localapp3", path = "/base/path/")
 	protected interface TestClient4 extends TestClient { }
 
-	@FeignClient(name = "localapp", path = "${test.path.prefix}")
+	@FeignClient(name = "localapp4", path = "${test.path.prefix}")
 	protected interface TestClient5 extends TestClient { }
 	
 	@Configuration
@@ -104,7 +107,8 @@ public class FeignRibbonClientPathTests {
 		TestClient1.class, TestClient2.class, TestClient3.class, TestClient4.class,
 		TestClient5.class
 	})
-	@RibbonClient(name = "localapp", configuration = LocalRibbonClientConfiguration.class)
+	@RibbonClients(defaultConfiguration = LocalRibbonClientConfiguration.class)
+	@Import(NoSecurityConfiguration.class)
 	public static class Application {
 
 		@RequestMapping(method = RequestMethod.GET, value = "/hello")

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignRibbonClientRetryTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignRibbonClientRetryTests.java
@@ -31,8 +31,10 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -78,6 +80,7 @@ public class FeignRibbonClientRetryTests {
 	@RestController
 	@EnableFeignClients(clients = TestClient.class)
 	@RibbonClient(name = "localapp", configuration = LocalRibbonClientConfiguration.class)
+	@Import(NoSecurityConfiguration.class)
 	public static class Application {
 
 		private AtomicInteger retries = new AtomicInteger(1);

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/FeignHttpClientPropertiesTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/FeignHttpClientPropertiesTests.java
@@ -23,6 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -32,7 +33,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.springframework.boot.test.util.EnvironmentTestUtils.addEnvironment;
 
 /**
  * @author Ryan Baxter
@@ -63,12 +63,12 @@ public class FeignHttpClientPropertiesTests {
 
 	@Test
 	public void testCustomization() {
-		addEnvironment(this.context, "feign.httpclient.maxConnections=2",
+		TestPropertyValues.of("feign.httpclient.maxConnections=2",
 				"feign.httpclient.connectionTimeout=2",
 				"feign.httpclient.maxConnectionsPerRoute=2",
 				"feign.httpclient.timeToLive=2",
 				"feign.httpclient.disableSslValidation=true",
-				"feign.httpclient.followRedirects=false");
+				"feign.httpclient.followRedirects=false").applyTo(this.context);
 		setupContext();
 		assertEquals(2, getProperties().getMaxConnections());
 		assertEquals(2, getProperties().getConnectionTimeout());

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringEncoderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringEncoderTests.java
@@ -40,9 +40,11 @@ import org.springframework.http.converter.AbstractGenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -50,6 +52,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import feign.RequestTemplate;
+import feign.codec.EncodeException;
 
 /**
  * @author Spencer Gibb
@@ -93,6 +96,31 @@ public class SpringEncoderTests {
 		RequestTemplate request = new RequestTemplate();
 
 		encoder.encode("hi".getBytes(), null, request);
+
+		assertThat("request charset is not null", request.charset(), is(nullValue()));
+	}
+
+	@Test(expected = EncodeException.class)
+	public void testMultipartFile1() {
+		SpringEncoder encoder = this.context.getInstance("foo", SpringEncoder.class);
+		assertThat(encoder, is(notNullValue()));
+		RequestTemplate request = new RequestTemplate();
+
+		MultipartFile multipartFile = new MockMultipartFile("test_multipart_file", "hi".getBytes());
+		encoder.encode(multipartFile, MultipartFile.class, request);
+
+		assertThat("request charset is not null", request.charset(), is(nullValue()));
+	}
+
+	@Test
+	public void testMultipartFile2() {
+		SpringEncoder encoder = this.context.getInstance("foo", SpringEncoder.class);
+		assertThat(encoder, is(notNullValue()));
+		RequestTemplate request = new RequestTemplate();
+		request = request.header("Content-Type", MediaType.MULTIPART_FORM_DATA_VALUE);
+
+		MultipartFile multipartFile = new MockMultipartFile("test_multipart_file", "hi".getBytes());
+		encoder.encode(multipartFile, MultipartFile.class, request);
 
 		assertThat("request charset is not null", request.charset(), is(nullValue()));
 	}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/test/NoSecurityConfiguration.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/test/NoSecurityConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package org.springframework.cloud.openfeign.test;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+
+@Configuration
+public class NoSecurityConfiguration extends WebSecurityConfigurerAdapter {
+	@Override
+	protected void configure(HttpSecurity http) throws Exception {
+		http.authorizeRequests()
+				.anyRequest().permitAll()
+				.and()
+				.csrf().disable();
+	}
+}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/FeignClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/FeignClientTests.java
@@ -47,8 +47,10 @@ import org.springframework.cloud.openfeign.support.FallbackCommand;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.format.Formatter;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.http.HttpEntity;
@@ -358,6 +360,7 @@ public class FeignClientTests {
 		@RibbonClient(name = "localapp4", configuration = LocalRibbonClientConfiguration.class),
 		@RibbonClient(name = "localapp5", configuration = LocalRibbonClientConfiguration.class)
 	})
+	@Import(NoSecurityConfiguration.class)
 	protected static class Application {
 
 		// needs to be in parent context to test multiple HystrixClient beans

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/FeignClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/FeignClientTests.java
@@ -20,6 +20,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.text.ParseException;
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -53,6 +54,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.format.Formatter;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -95,6 +97,7 @@ import rx.Single;
  * @author Spencer Gibb
  * @author Jakub Narloch
  * @author Erik Kringen
+ * @author Halvdan Hoem Grelland
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = FeignClientTests.Application.class, webEnvironment = WebEnvironment.RANDOM_PORT, value = {
@@ -188,6 +191,11 @@ public class FeignClientTests {
 
 		@RequestMapping(method = RequestMethod.GET, path = "/helloparams")
 		List<String> getParams(@RequestParam("params") List<String> params);
+
+		@RequestMapping(method = RequestMethod.GET, path = "/formattedparams")
+		List<LocalDate> getFormattedParams(
+				@RequestParam("params")
+				@DateTimeFormat(pattern = "dd-MM-yyyy") List<LocalDate> params);
 
 		@RequestMapping(method = RequestMethod.GET, path = "/hellos")
 		HystrixCommand<List<Hello>> getHellosHystrix();
@@ -444,6 +452,13 @@ public class FeignClientTests {
 			return params;
 		}
 
+		@RequestMapping(method = RequestMethod.GET, path = "/formattedparams")
+		public List<LocalDate> getFormattedParams(
+				@RequestParam("params")
+				@DateTimeFormat(pattern = "dd-MM-yyyy") List<LocalDate> params) {
+			return params;
+		}
+
 		@RequestMapping(method = RequestMethod.GET, path = "/noContent")
 		ResponseEntity<Void> noContent() {
 			return ResponseEntity.noContent().build();
@@ -584,6 +599,15 @@ public class FeignClientTests {
 		List<String> params = this.testClient.getParams(list);
 		assertNotNull("params was null", params);
 		assertEquals("params size was wrong", list.size(), params.size());
+	}
+
+	@Test
+	public void testFormattedParams() {
+		List<LocalDate> list = Arrays.asList(
+				LocalDate.of(2001, 1, 1), LocalDate.of(2018, 6, 10));
+		List<LocalDate> params = this.testClient.getFormattedParams(list);
+		assertNotNull("params was null", params);
+		assertEquals("params not converted correctly", list, params);
 	}
 
 	@Test

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/FeignHttpClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/FeignHttpClientTests.java
@@ -25,13 +25,16 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.cloud.openfeign.ribbon.LoadBalancerFeignClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
@@ -95,7 +98,7 @@ public class FeignHttpClientTests {
 		User getUser(@PathVariable("id") long id);
 	}
 
-	@FeignClient("localapp")
+	@FeignClient("localapp1")
 	protected interface UserClient extends UserService {
 	}
 
@@ -103,7 +106,11 @@ public class FeignHttpClientTests {
 	@EnableAutoConfiguration
 	@RestController
 	@EnableFeignClients(clients = { TestClient.class, UserClient.class })
-	@RibbonClient(name = "localapp", configuration = LocalRibbonClientConfiguration.class)
+	@RibbonClients({
+			@RibbonClient(name = "localapp", configuration = LocalRibbonClientConfiguration.class),
+			@RibbonClient(name = "localapp1", configuration = LocalRibbonClientConfiguration.class)
+	})
+	@Import(NoSecurityConfiguration.class)
 	protected static class Application implements UserService {
 
 		@RequestMapping(method = RequestMethod.GET, value = "/hello")

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/FeignOkHttpTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/FeignOkHttpTests.java
@@ -24,13 +24,16 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.cloud.openfeign.ribbon.LoadBalancerFeignClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -96,7 +99,7 @@ public class FeignOkHttpTests {
 		User getUser(@PathVariable("id") long id);
 	}
 
-	@FeignClient("localapp")
+	@FeignClient("localapp1")
 	protected interface UserClient extends UserService {
 	}
 
@@ -104,7 +107,11 @@ public class FeignOkHttpTests {
 	@EnableAutoConfiguration
 	@RestController
 	@EnableFeignClients(clients = { TestClient.class, UserClient.class })
-	@RibbonClient(name = "localapp", configuration = LocalRibbonClientConfiguration.class)
+	@RibbonClients({
+			@RibbonClient(name = "localapp", configuration = LocalRibbonClientConfiguration.class),
+			@RibbonClient(name = "localapp1", configuration = LocalRibbonClientConfiguration.class)
+	})
+	@Import(NoSecurityConfiguration.class)
 	protected static class Application implements UserService {
 
 		@RequestMapping(method = RequestMethod.GET, value = "/hello")

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/scanning/FeignClientEnvVarTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/scanning/FeignClientEnvVarTests.java
@@ -24,11 +24,13 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.cloud.openfeign.testclients.TestClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -66,6 +68,7 @@ public class FeignClientEnvVarTests {
 	@RestController
 	@EnableFeignClients(basePackages = {"${basepackage}"})
 	@RibbonClient(name = "localapp", configuration = LocalRibbonClientConfiguration.class)
+	@Import(NoSecurityConfiguration.class)
 	protected static class Application {
 		@RequestMapping(method = RequestMethod.GET, value = "/hello")
 		public String getHello() {

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/scanning/FeignClientScanningTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/scanning/FeignClientScanningTests.java
@@ -23,12 +23,15 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.cloud.netflix.ribbon.RibbonClients;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.cloud.netflix.ribbon.RibbonClient;
 import org.springframework.cloud.netflix.ribbon.StaticServerList;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -65,7 +68,7 @@ public class FeignClientScanningTests {
 	@SuppressWarnings("unused")
 	private Client feignClient;
 
-	@FeignClient("localapp")
+	@FeignClient("localapp123")
 	protected interface TestClient {
 		@RequestMapping(method = RequestMethod.GET, value = "/hello")
 		String getHello();
@@ -81,7 +84,8 @@ public class FeignClientScanningTests {
 	@EnableAutoConfiguration
 	@RestController
 	@EnableFeignClients // NO clients attribute. That's what this class is testing!
-	@RibbonClient(name = "localapp", configuration = LocalRibbonClientConfiguration.class)
+	@RibbonClients(defaultConfiguration = LocalRibbonClientConfiguration.class)
+	@Import(NoSecurityConfiguration.class)
 	protected static class Application {
 		@RequestMapping(method = RequestMethod.GET, value = "/hello")
 		public String getHello() {

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -14,6 +14,7 @@
 	<description>Spring Cloud OpenFeign Dependencies</description>
 	<properties>
 		<feign.version>9.7.0</feign.version>
+		<feign-form.version>3.3.0</feign-form.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -31,6 +32,11 @@
 				<groupId>io.github.openfeign</groupId>
 				<artifactId>feign-core</artifactId>
 				<version>${feign.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.github.openfeign.form</groupId>
+				<artifactId>feign-form-spring</artifactId>
+				<version>${feign-form.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.github.openfeign</groupId>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -13,7 +13,7 @@
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>
 	<properties>
-		<feign.version>9.5.1</feign.version>
+		<feign.version>9.7.0</feign.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -5,11 +5,10 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>2.0.3.RELEASE</version>
-		<relativePath/>
+		<version>2.1.0.BUILD-SNAPSHOT</version>		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>2.0.2.BUILD-SNAPSHOT</version>
+	<version>2.1.0.BUILD-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>2.0.2.BUILD-SNAPSHOT</version>
+		<version>2.1.0.BUILD-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<artifactId>spring-cloud-starter-openfeign</artifactId>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -40,6 +40,10 @@
 			<artifactId>feign-core</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>io.github.openfeign.form</groupId>
+			<artifactId>feign-form-spring</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.github.openfeign</groupId>
 			<artifactId>feign-slf4j</artifactId>
 		</dependency>


### PR DESCRIPTION
Proposed solution for https://github.com/spring-cloud/spring-cloud-openfeign/issues/62

### Notes
The solution is based on
```
        <dependency>
            <groupId>io.github.openfeign.form</groupId>
            <artifactId>feign-form-spring</artifactId>
            <version>3.3.0</version>
        </dependency>
```

Class `feign.form.spring.SpringFormEncoder` was added inside `org.springframework.cloud.openfeign.support.SpringEncoder` because it's doesn't has some checks:
1. Check of  `bodyType` on null.
`org.springframework.cloud.openfeign.support.SpringEncoder#encode` don't handle situation when `bodyType` is null.

2. No check for content type `multipart/form-data` in header. 
`feign.form.FormEncoder` requires `multipart/form-data` in header for proper processing.

All this checks added and tests are passed.