### PR TITLE
Added support for MultipartFile

### DIFF
--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -94,6 +94,10 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
+			<groupId>io.github.openfeign.form</groupId>
+			<artifactId>feign-form-spring</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>io.github.openfeign</groupId>
 			<artifactId>feign-slf4j</artifactId>
 			<optional>true</optional>

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringEncoderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringEncoderTests.java
@@ -40,9 +40,11 @@ import org.springframework.http.converter.AbstractGenericHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -50,6 +52,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
 import feign.RequestTemplate;
+import feign.codec.EncodeException;
 
 /**
  * @author Spencer Gibb
@@ -93,6 +96,31 @@ public class SpringEncoderTests {
 		RequestTemplate request = new RequestTemplate();
 
 		encoder.encode("hi".getBytes(), null, request);
+
+		assertThat("request charset is not null", request.charset(), is(nullValue()));
+	}
+
+	@Test(expected = EncodeException.class)
+	public void testMultipartFile1() {
+		SpringEncoder encoder = this.context.getInstance("foo", SpringEncoder.class);
+		assertThat(encoder, is(notNullValue()));
+		RequestTemplate request = new RequestTemplate();
+
+		MultipartFile multipartFile = new MockMultipartFile("test_multipart_file", "hi".getBytes());
+		encoder.encode(multipartFile, MultipartFile.class, request);
+
+		assertThat("request charset is not null", request.charset(), is(nullValue()));
+	}
+
+	@Test
+	public void testMultipartFile2() {
+		SpringEncoder encoder = this.context.getInstance("foo", SpringEncoder.class);
+		assertThat(encoder, is(notNullValue()));
+		RequestTemplate request = new RequestTemplate();
+		request = request.header("Content-Type", MediaType.MULTIPART_FORM_DATA_VALUE);
+
+		MultipartFile multipartFile = new MockMultipartFile("test_multipart_file", "hi".getBytes());
+		encoder.encode(multipartFile, MultipartFile.class, request);
 
 		assertThat("request charset is not null", request.charset(), is(nullValue()));
 	}

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -15,6 +15,7 @@
 	<description>Spring Cloud OpenFeign Dependencies</description>
 	<properties>
 		<feign.version>9.5.1</feign.version>
+		<feign-form.version>3.3.0</feign-form.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -32,6 +33,11 @@
 				<groupId>io.github.openfeign</groupId>
 				<artifactId>feign-core</artifactId>
 				<version>${feign.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.github.openfeign.form</groupId>
+				<artifactId>feign-form-spring</artifactId>
+				<version>${feign-form.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>io.github.openfeign</groupId>


### PR DESCRIPTION
Proposed solution for https://github.com/spring-cloud/spring-cloud-openfeign/issues/62

### Notes
The solution is based on
```
        <dependency>
            <groupId>io.github.openfeign.form</groupId>
            <artifactId>feign-form-spring</artifactId>
            <version>3.3.0</version>
        </dependency>
```

Class `feign.form.spring.SpringFormEncoder` was added inside `org.springframework.cloud.openfeign.support.SpringEncoder` because it's doesn't has some checks:
1. Check of  `bodyType` on null.
`org.springframework.cloud.openfeign.support.SpringEncoder#encode` don't handle situation when `bodyType` is null.

2. No check for content type `multipart/form-data` in header. 
`feign.form.FormEncoder` requires `multipart/form-data` in header for proper processing.

All this checks added and tests are passed.