### PR TITLE
Add support for feign's QueryMap annotation for Object mapping

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/QueryMapParameterProcessor.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/QueryMapParameterProcessor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2013-2018 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.cloud.openfeign.annotation;
 
 import feign.MethodMetadata;

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/QueryMapParameterProcessor.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/QueryMapParameterProcessor.java
@@ -1,0 +1,35 @@
+package org.springframework.cloud.openfeign.annotation;
+
+import feign.MethodMetadata;
+import feign.QueryMap;
+import org.springframework.cloud.openfeign.AnnotatedParameterProcessor;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+/**
+ * {@link QueryMap} parameter processor.
+ *
+ * @author Aram Peres
+ * @see AnnotatedParameterProcessor
+ */
+public class QueryMapParameterProcessor implements AnnotatedParameterProcessor {
+
+	private static final Class<QueryMap> ANNOTATION = QueryMap.class;
+
+	@Override
+	public Class<? extends Annotation> getAnnotationType() {
+		return ANNOTATION;
+	}
+
+	@Override
+	public boolean processArgument(AnnotatedParameterContext context, Annotation annotation, Method method) {
+		int paramIndex = context.getParameterIndex();
+		MethodMetadata metadata = context.getMethodMetadata();
+		if (metadata.queryMapIndex() == null) {
+			metadata.queryMapIndex(paramIndex);
+			metadata.queryMapEncoded(QueryMap.class.cast(annotation).encoded());
+		}
+		return true;
+	}
+}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -31,6 +31,7 @@ import java.util.Map;
 
 import org.springframework.cloud.openfeign.AnnotatedParameterProcessor;
 import org.springframework.cloud.openfeign.annotation.PathVariableParameterProcessor;
+import org.springframework.cloud.openfeign.annotation.QueryMapParameterProcessor;
 import org.springframework.cloud.openfeign.annotation.RequestHeaderParameterProcessor;
 import org.springframework.cloud.openfeign.annotation.RequestParamParameterProcessor;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -62,6 +63,7 @@ import feign.Param;
  * @author Spencer Gibb
  * @author Abhijit Sarkar
  * @author Halvdan Hoem Grelland
+ * @author Aram Peres
  */
 public class SpringMvcContract extends Contract.BaseContract
 		implements ResourceLoaderAware {
@@ -332,6 +334,7 @@ public class SpringMvcContract extends Contract.BaseContract
 		annotatedArgumentResolvers.add(new PathVariableParameterProcessor());
 		annotatedArgumentResolvers.add(new RequestParamParameterProcessor());
 		annotatedArgumentResolvers.add(new RequestHeaderParameterProcessor());
+		annotatedArgumentResolvers.add(new QueryMapParameterProcessor());
 
 		return annotatedArgumentResolvers;
 	}


### PR DESCRIPTION
The `@QueryMap` annotation in OpenFeign allows support for Map-to-query and Object-to-query encoding. In the current state, there's an inconsistency between OpenFeign and spring-cloud-openfeign:

* In OpenFeign, you can mark an Object parameter with `@QueryMap` to use it as query parameters instead of a body.
* In Spring, having an Object parameter in a GET mapping will map it to query automatically. Therefore, there is no equivalent annotation for `@QueryMap`.

Since `SpringMvcContract` overrides the Feign BaseContract, which handles the QueryMap annotation, having an Object parameter would pass it as a body instead of query parameters.

**Another solution** to this inconsistency would be to modify the `RequestParamParameterProcessor` to allow for Object parameters for QueryMap *if* the method  in question is a GET. Let me know if you'd rather have such a solution instead.