### PR TITLE
 Add feign-mock dependency

### DIFF
--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -95,6 +95,11 @@
 			</dependency>
 			<dependency>
 				<groupId>io.github.openfeign</groupId>
+				<artifactId>feign-mock</artifactId>
+				<version>${feign.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.github.openfeign</groupId>
 				<artifactId>feign-ribbon</artifactId>
 				<version>${feign.version}</version>
 			</dependency>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -55,11 +55,6 @@
 			</dependency>
 			<dependency>
 				<groupId>io.github.openfeign</groupId>
-				<artifactId>feign-java8</artifactId>
-				<version>${feign.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>io.github.openfeign</groupId>
 				<artifactId>feign-okhttp</artifactId>
 				<version>${feign.version}</version>
 			</dependency>


### PR DESCRIPTION
Please consider adding feign-mock to dependencies, so it can be picked up when using BOM. I am using it in my tests and need to specify version manually.

https://github.com/OpenFeign/feign/tree/master/mock