### PR TITLE
URL Cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-# EditorConfig is awesome: http://EditorConfig.org
+# EditorConfig is awesome: https://EditorConfig.org
 
 # top-most EditorConfig file
 root = true

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -28,7 +28,7 @@ added after the original pull request but before a merge.
   you can import formatter settings using the
   `eclipse-code-formatter.xml` file from the
   [Spring Cloud Build](https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml) project. If using IntelliJ, you can use the
-  [Eclipse Code Formatter Plugin](http://plugins.jetbrains.com/plugin/6546) to import the same file.
+  [Eclipse Code Formatter Plugin](https://plugins.jetbrains.com/plugin/6546) to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
   for.
@@ -40,6 +40,6 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow [these conventions](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
+* When writing a commit message please follow [these conventions](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html),
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).

--- a/README.adoc
+++ b/README.adoc
@@ -55,7 +55,7 @@ credentials and you already have those.
 
 The projects that require middleware generally include a
 `docker-compose.yml`, so consider using
-http://compose.docker.io/[Docker Compose] to run the middeware servers
+https://compose.docker.io/[Docker Compose] to run the middeware servers
 in Docker containers. See the README in the
 https://github.com/spring-cloud-samples/scripts[scripts demo
 repository] for specific instructions about the common cases of mongo,
@@ -77,13 +77,13 @@ a modified file in the correct place. Just commit it and push the change.
 
 === Working with the code
 If you don't have an IDE preference we would recommend that you use
-http://www.springsource.com/developer/sts[Spring Tools Suite] or
-http://eclipse.org[Eclipse] when working with the code. We use the
-http://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
+https://www.springsource.com/developer/sts[Spring Tools Suite] or
+https://eclipse.org[Eclipse] when working with the code. We use the
+https://eclipse.org/m2e/[m2eclipse] eclipse plugin for maven support. Other IDEs and tools
 should also work without issue as long as they use Maven 3.3.3 or better.
 
 ==== Importing into eclipse with m2eclipse
-We recommend the http://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
+We recommend the https://eclipse.org/m2e/[m2eclipse] eclipse plugin when working with
 eclipse. If you don't already have m2eclipse installed it is available from the "eclipse
 marketplace".
 
@@ -142,7 +142,7 @@ added after the original pull request but before a merge.
   `eclipse-code-formatter.xml` file from the
   https://raw.githubusercontent.com/spring-cloud/spring-cloud-build/master/spring-cloud-dependencies-parent/eclipse-code-formatter.xml[Spring
   Cloud Build] project. If using IntelliJ, you can use the
-  http://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
+  https://plugins.jetbrains.com/plugin/6546[Eclipse Code Formatter
   Plugin] to import the same file.
 * Make sure all new `.java` files to have a simple Javadoc class comment with at least an
   `@author` tag identifying you, and preferably at least a paragraph on what the class is
@@ -155,7 +155,7 @@ added after the original pull request but before a merge.
 * A few unit tests would help a lot as well -- someone has to do it.
 * If no-one else is using your branch, please rebase it against the current master (or
   other target branch in the main project).
-* When writing a commit message please follow http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
+* When writing a commit message please follow https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html[these conventions],
   if you are fixing an existing issue please add `Fixes gh-XXXX` at the end of the commit
   message (where XXXX is the issue number).
 
@@ -226,7 +226,7 @@ If you need to suppress some rules (e.g. line length needs to be longer), then i
 <?xml version="1.0"?>
 <!DOCTYPE suppressions PUBLIC
 		"-//Puppy Crawl//DTD Suppressions 1.1//EN"
-		"http://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
+		"https://www.puppycrawl.com/dtds/suppressions_1_1.dtd">
 <suppressions>
 	<suppress files=".*ConfigServerApplication\.java" checks="HideUtilityClassConstructor"/>
 	<suppress files=".*ConfigClientWatch\.java" checks="LineLengthCheck"/>

--- a/asciidoctor.css
+++ b/asciidoctor.css
@@ -1,4 +1,4 @@
-/* Asciidoctor default stylesheet | MIT License | http://asciidoctor.org */
+/* Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
 /* Remove the comments around the @import statement below when using this as a custom stylesheet */
 /*@import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic|Noto+Serif:400,400italic,700,700italic|Droid+Sans+Mono:400";*/
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {

--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -1,7 +1,7 @@
 :github-tag: master
 :github-repo: spring-cloud/spring-cloud-openfeign
-:github-raw: http://raw.github.com/{github-repo}/{github-tag}
-:github-code: http://github.com/{github-repo}/tree/{github-tag}
+:github-raw: https://raw.github.com/{github-repo}/{github-tag}
+:github-code: https://github.com/{github-repo}/tree/{github-tag}
 :all: {asterisk}{asterisk}
 :nofooter:
 :branch: master
@@ -21,7 +21,7 @@ https://github.com/Netflix/feign[Feign] is a declarative web service client.  It
 === How to Include Feign
 
 To include Feign in your project use the starter with group `org.springframework.cloud`
-and artifact id `spring-cloud-starter-openfeign`. See the http://projects.spring.io/spring-cloud/[Spring Cloud Project page]
+and artifact id `spring-cloud-starter-openfeign`. See the https://projects.spring.io/spring-cloud/[Spring Cloud Project page]
 for details on setting up your build system with the current Spring Cloud Release Train.
 
 Example spring boot app
@@ -257,14 +257,14 @@ class FooController {
 				.decoder(decoder)
 				.contract(contract)
 				.requestInterceptor(new BasicAuthRequestInterceptor("user", "user"))
-				.target(FooClient.class, "http://PROD-SVC");
+				.target(FooClient.class, "https://PROD-SVC");
 
 		this.adminClient = Feign.builder().client(client)
 				.encoder(encoder)
 				.decoder(decoder)
 				.contract(contract)
 				.requestInterceptor(new BasicAuthRequestInterceptor("admin", "admin"))
-				.target(FooClient.class, "http://PROD-SVC");
+				.target(FooClient.class, "https://PROD-SVC");
     }
 }
 ----

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientBuilderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientBuilderTests.java
@@ -136,7 +136,7 @@ public class FeignClientBuilderTests {
 		assertFactoryBeanField(builder, "name", "TestClient");
 
 		// and:
-		assertFactoryBeanField(builder, "url", "http://Url/");
+		assertFactoryBeanField(builder, "url", "https://Url/");
 		assertFactoryBeanField(builder, "path", "/Path");
 		assertFactoryBeanField(builder, "decode404", true);
 		assertFactoryBeanField(builder, "fallback", Object.class);

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientOverrideDefaultsTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientOverrideDefaultsTests.java
@@ -141,7 +141,7 @@ public class FeignClientOverrideDefaultsTests {
 				.isEqualTo(2);
 	}
 
-	@FeignClient(name = "foo", url = "http://foo", configuration = FooConfiguration.class)
+	@FeignClient(name = "foo", url = "https://foo", configuration = FooConfiguration.class)
 	interface FooClient {
 
 		@RequestLine("GET /")
@@ -149,7 +149,7 @@ public class FeignClientOverrideDefaultsTests {
 
 	}
 
-	@FeignClient(name = "bar", url = "http://bar", configuration = BarConfiguration.class)
+	@FeignClient(name = "bar", url = "https://bar", configuration = BarConfiguration.class)
 	interface BarClient {
 
 		@RequestMapping(value = "/", method = RequestMethod.GET)

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientsRegistrarTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientsRegistrarTests.java
@@ -37,7 +37,7 @@ public class FeignClientsRegistrarTests {
 
 	@Test(expected = IllegalStateException.class)
 	public void badNameHttpPrefix() {
-		testGetName("http://bad_hostname");
+		testGetName("https://bad_hostname");
 	}
 
 	@Test(expected = IllegalStateException.class)
@@ -63,8 +63,8 @@ public class FeignClientsRegistrarTests {
 
 	@Test
 	public void goodNameHttpPrefix() {
-		String name = testGetName("http://good-name");
-		assertThat(name).as("name was wrong").isEqualTo("http://good-name");
+		String name = testGetName("https://good-name");
+		assertThat(name).as("name was wrong").isEqualTo("https://good-name");
 	}
 
 	@Test

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignLoadBalancerTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignLoadBalancerTests.java
@@ -96,7 +96,7 @@ public class FeignLoadBalancerTests {
 
 		this.feignLoadBalancer = new FeignLoadBalancer(this.lb, this.config,
 				this.inspector);
-		Request request = new RequestTemplate().method(GET).target("http://foo/")
+		Request request = new RequestTemplate().method(GET).target("https://foo/")
 				.resolve(new HashMap<>()).request();
 		RibbonRequest ribbonRequest = new RibbonRequest(this.delegate, request,
 				new URI(request.url()));
@@ -108,7 +108,7 @@ public class FeignLoadBalancerTests {
 
 		RibbonResponse resp = this.feignLoadBalancer.execute(ribbonRequest, null);
 
-		assertThat(resp.getRequestedURI()).isEqualTo(new URI("http://foo"));
+		assertThat(resp.getRequestedURI()).isEqualTo(new URI("https://foo"));
 	}
 
 	@Test
@@ -118,7 +118,7 @@ public class FeignLoadBalancerTests {
 				this.inspector);
 		Server server = new Server("foo", 7777);
 		URI uri = this.feignLoadBalancer.reconstructURIWithServer(server,
-				new URI("http://foo/"));
+				new URI("https://foo/"));
 		assertThat(uri).isEqualTo(new URI("https://foo:7777/"));
 	}
 
@@ -140,8 +140,8 @@ public class FeignLoadBalancerTests {
 				});
 		Server server = new Server("foo", 7777);
 		URI uri = this.feignLoadBalancer.reconstructURIWithServer(server,
-				new URI("http://foo/"));
-		assertThat(uri).isEqualTo(new URI("http://foo:7777/"));
+				new URI("https://foo/"));
+		assertThat(uri).isEqualTo(new URI("https://foo:7777/"));
 	}
 
 	@Test
@@ -152,13 +152,13 @@ public class FeignLoadBalancerTests {
 		when(server.getPort()).thenReturn(443);
 		when(server.getHost()).thenReturn("foo");
 		URI uri = this.feignLoadBalancer.reconstructURIWithServer(server,
-				new URI("http://bar/"));
+				new URI("https://bar/"));
 		assertThat(uri).isEqualTo(new URI("https://foo:443/"));
 	}
 
 	@Test
 	public void testRibbonRequestURLEncode() throws Exception {
-		String url = "http://foo/?name=%7bcookie"; // name={cookie
+		String url = "https://foo/?name=%7bcookie"; // name={cookie
 		Request request = Request.create(GET, url, new HashMap<>(), null, null);
 
 		assertThat(request.url()).isEqualTo(url);

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignRibbonClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/FeignRibbonClientTests.java
@@ -98,28 +98,28 @@ public class FeignRibbonClientTests {
 
 	@Test
 	public void remoteRequestIsSentAtRoot() throws Exception {
-		Request request = new RequestTemplate().method(GET).target("http://foo")
+		Request request = new RequestTemplate().method(GET).target("https://foo")
 				.resolve(new HashMap<>()).request();
 		this.client.execute(request, new Options());
-		RequestMatcher matcher = new RequestMatcher("http://foo.com:8000/");
+		RequestMatcher matcher = new RequestMatcher("https://foo.com:8000/");
 		verify(this.delegate).execute(argThat(matcher), any(Options.class));
 	}
 
 	@Test
 	public void remoteRequestIsSent() throws Exception {
-		Request request = new RequestTemplate().method(GET).target("http://foo/")
+		Request request = new RequestTemplate().method(GET).target("https://foo/")
 				.resolve(new HashMap<>()).request();
 		this.client.execute(request, new Options());
-		RequestMatcher matcher = new RequestMatcher("http://foo.com:8000/");
+		RequestMatcher matcher = new RequestMatcher("https://foo.com:8000/");
 		verify(this.delegate).execute(argThat(matcher), any(Options.class));
 	}
 
 	@Test
 	public void verifyCleanUrl() throws Exception {
 		Request request = new RequestTemplate().method(GET)
-				.target("http://tp/abc/bcd.json").resolve(new HashMap<>()).request();
+				.target("https://tp/abc/bcd.json").resolve(new HashMap<>()).request();
 		this.client.execute(request, new Options());
-		RequestMatcher matcher = new RequestMatcher("http://foo.com:8000/abc/bcd.json");
+		RequestMatcher matcher = new RequestMatcher("https://foo.com:8000/abc/bcd.json");
 		verify(this.delegate).execute(argThat(matcher), any(Options.class));
 	}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/RetryableFeignLoadBalancerTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/RetryableFeignLoadBalancerTests.java
@@ -132,11 +132,11 @@ public class RetryableFeignLoadBalancerTests {
 		doReturn(config).when(clientFactory).getClientConfig(eq("default"));
 		RibbonLoadBalancedRetryFactory loadBalancedRetryFactory = new RibbonLoadBalancedRetryFactory(
 				clientFactory);
-		Request feignRequest = Request.create(GET, "http://foo", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://foo", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://foo"));
+				client, feignRequest, new URI("https://foo"));
 		Response response = Response.builder().status(200).request(feignRequest)
 				.headers(new HashMap<>()).build();
 		doReturn(response).when(client).execute(any(Request.class),
@@ -150,11 +150,11 @@ public class RetryableFeignLoadBalancerTests {
 
 	@Test
 	public void executeNeverRetry() throws Exception {
-		Request feignRequest = Request.create(GET, "http://foo", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://foo", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://foo"));
+				client, feignRequest, new URI("https://foo"));
 		doThrow(new IOException("boom")).when(client).execute(any(Request.class),
 				any(Request.Options.class));
 		RetryableFeignLoadBalancer feignLb = new RetryableFeignLoadBalancer(this.lb,
@@ -214,11 +214,11 @@ public class RetryableFeignLoadBalancerTests {
 				return backOffPolicy;
 			}
 		};
-		Request feignRequest = Request.create(GET, "http://foo", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://foo", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://foo"));
+				client, feignRequest, new URI("https://foo"));
 		Response response = Response.builder().status(200).request(feignRequest)
 				.headers(new HashMap<>()).build();
 		doThrow(new IOException("boom")).doReturn(response).when(client)
@@ -259,11 +259,11 @@ public class RetryableFeignLoadBalancerTests {
 				return backOffPolicy;
 			}
 		};
-		Request feignRequest = Request.create(GET, "http://foo", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://foo", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://foo"));
+				client, feignRequest, new URI("https://foo"));
 		Response response = Response.builder().request(feignRequest).status(200)
 				.headers(new HashMap<>()).build();
 		Response fourOFourResponse = Response.builder().request(feignRequest).status(404)
@@ -309,11 +309,11 @@ public class RetryableFeignLoadBalancerTests {
 				return backOffPolicy;
 			}
 		};
-		Request feignRequest = Request.create(GET, "http://foo", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://foo", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://foo"));
+				client, feignRequest, new URI("https://foo"));
 		Response response = Response.builder().request(feignRequest).status(404)
 				.headers(new HashMap<>()).build();
 		Response fourOFourResponse = Response.builder().request(feignRequest).status(404)
@@ -338,11 +338,11 @@ public class RetryableFeignLoadBalancerTests {
 		doReturn(lbContext).when(clientFactory).getLoadBalancerContext(any(String.class));
 		RibbonLoadBalancedRetryFactory loadBalancedRetryFactory = new RibbonLoadBalancedRetryFactory(
 				clientFactory);
-		Request feignRequest = Request.create(GET, "http://foo", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://foo", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://foo"));
+				client, feignRequest, new URI("https://foo"));
 		Response response = Response.builder().request(feignRequest).status(200)
 				.headers(new HashMap<>()).build();
 		doReturn(response).when(client).execute(any(Request.class),
@@ -364,11 +364,11 @@ public class RetryableFeignLoadBalancerTests {
 		doReturn(lbContext).when(clientFactory).getLoadBalancerContext(any(String.class));
 		RibbonLoadBalancedRetryFactory loadBalancedRetryFactory = new RibbonLoadBalancedRetryFactory(
 				clientFactory);
-		Request feignRequest = Request.create(GET, "http://foo", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://foo", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://foo"));
+				client, feignRequest, new URI("https://foo"));
 		Response response = Response.builder().request(feignRequest).status(200)
 				.headers(new HashMap<>()).build();
 		doReturn(response).when(client).execute(any(Request.class),
@@ -445,11 +445,11 @@ public class RetryableFeignLoadBalancerTests {
 				return backOffPolicy;
 			}
 		};
-		Request feignRequest = Request.create(GET, "http://listener", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://listener", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://listener"));
+				client, feignRequest, new URI("https://listener"));
 		Response response = Response.builder().request(feignRequest).status(200)
 				.headers(new HashMap<>()).build();
 		doThrow(new IOException("boom")).doReturn(response).when(client)
@@ -497,11 +497,11 @@ public class RetryableFeignLoadBalancerTests {
 				return backOffPolicy;
 			}
 		};
-		Request feignRequest = Request.create(GET, "http://listener", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://listener", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://listener"));
+				client, feignRequest, new URI("https://listener"));
 		RetryableFeignLoadBalancer feignLb = new RetryableFeignLoadBalancer(this.lb,
 				config, this.inspector, loadBalancedRetryFactory);
 		FeignLoadBalancer.RibbonResponse ribbonResponse = feignLb.execute(request, null);
@@ -534,11 +534,11 @@ public class RetryableFeignLoadBalancerTests {
 				return backOffPolicy;
 			}
 		};
-		Request feignRequest = Request.create(GET, "http://listener", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://listener", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://listener"));
+				client, feignRequest, new URI("https://listener"));
 		Response response = Response.builder().request(feignRequest).status(200)
 				.headers(new HashMap<>()).build();
 		doThrow(new IOException("boom")).doReturn(response).when(client)
@@ -579,11 +579,11 @@ public class RetryableFeignLoadBalancerTests {
 				return backOffPolicy;
 			}
 		};
-		Request feignRequest = Request.create(GET, "http://foo", new HashMap<>(),
+		Request feignRequest = Request.create(GET, "https://foo", new HashMap<>(),
 				new byte[] {}, UTF_8);
 		Client client = mock(Client.class);
 		FeignLoadBalancer.RibbonRequest request = new FeignLoadBalancer.RibbonRequest(
-				client, feignRequest, new URI("http://foo"));
+				client, feignRequest, new URI("https://foo"));
 		Response fourOFourResponse = Response.builder().request(feignRequest).status(404)
 				.headers(new HashMap<>()).body(new Response.Body() { // set content into
 																		// response

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/RibbonResponseStatusCodeExceptionTest.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/ribbon/RibbonResponseStatusCodeExceptionTest.java
@@ -48,7 +48,7 @@ public class RibbonResponseStatusCodeExceptionTest {
 		List<String> fooValues = new ArrayList<String>();
 		fooValues.add("bar");
 		headers.put("foo", fooValues);
-		Request request = Request.create(GET, "http://service.com",
+		Request request = Request.create(GET, "https://service.com",
 				new HashMap<String, Collection<String>>(), new byte[] {},
 				Charset.defaultCharset());
 		byte[] body = "foo".getBytes();

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/FeignClientValidationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/FeignClientValidationTests.java
@@ -69,7 +69,7 @@ public class FeignClientValidationTests {
 	@EnableFeignClients(clients = GoodUrlConfiguration.Client.class)
 	protected static class GoodUrlConfiguration {
 
-		@FeignClient(name = "example", url = "http://example.com")
+		@FeignClient(name = "example", url = "https://example.com")
 		interface Client {
 
 			@RequestMapping(method = RequestMethod.GET, value = "/")
@@ -85,7 +85,7 @@ public class FeignClientValidationTests {
 	@EnableFeignClients(clients = PlaceholderUrlConfiguration.Client.class)
 	protected static class PlaceholderUrlConfiguration {
 
-		@FeignClient(name = "example", url = "${feignClient.url:http://example.com}")
+		@FeignClient(name = "example", url = "${feignClient.url:https://example.com}")
 		interface Client {
 
 			@RequestMapping(method = RequestMethod.GET, value = "/")


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://foo.com:8000/ (ConnectTimeoutException) with 2 occurrences migrated to:  
  https://foo.com:8000/ ([https](https://foo.com:8000/) result ConnectTimeoutException).
* [ ] http://foo.com:8000/abc/bcd.json (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://foo.com:8000/abc/bcd.json ([https](https://foo.com:8000/abc/bcd.json) result ConnectTimeoutException).
* [ ] http://PROD-SVC (UnknownHostException) with 2 occurrences migrated to:  
  https://PROD-SVC ([https](https://PROD-SVC) result UnknownHostException).
* [ ] http://Url/ (UnknownHostException) with 1 occurrences migrated to:  
  https://Url/ ([https](https://Url/) result UnknownHostException).
* [ ] http://bad_hostname (UnknownHostException) with 1 occurrences migrated to:  
  https://bad_hostname ([https](https://bad_hostname) result UnknownHostException).
* [ ] http://bar (UnknownHostException) with 1 occurrences migrated to:  
  https://bar ([https](https://bar) result UnknownHostException).
* [ ] http://bar/ (UnknownHostException) with 1 occurrences migrated to:  
  https://bar/ ([https](https://bar/) result UnknownHostException).
* [ ] http://compose.docker.io/ (UnknownHostException) with 1 occurrences migrated to:  
  https://compose.docker.io/ ([https](https://compose.docker.io/) result UnknownHostException).
* [ ] http://foo (UnknownHostException) with 19 occurrences migrated to:  
  https://foo ([https](https://foo) result UnknownHostException).
* [ ] http://foo/ (UnknownHostException) with 4 occurrences migrated to:  
  https://foo/ ([https](https://foo/) result UnknownHostException).
* [ ] http://foo/?name=%7bcookie (UnknownHostException) with 1 occurrences migrated to:  
  https://foo/?name=%7bcookie ([https](https://foo/?name=%7bcookie) result UnknownHostException).
* [ ] http://foo:7777/ (UnknownHostException) with 1 occurrences migrated to:  
  https://foo:7777/ ([https](https://foo:7777/) result UnknownHostException).
* [ ] http://good-name (UnknownHostException) with 2 occurrences migrated to:  
  https://good-name ([https](https://good-name) result UnknownHostException).
* [ ] http://listener (UnknownHostException) with 6 occurrences migrated to:  
  https://listener ([https](https://listener) result UnknownHostException).
* [ ] http://tp/abc/bcd.json (UnknownHostException) with 1 occurrences migrated to:  
  https://tp/abc/bcd.json ([https](https://tp/abc/bcd.json) result UnknownHostException).
* [ ] http://www.puppycrawl.com/dtds/suppressions_1_1.dtd (404) with 1 occurrences migrated to:  
  https://www.puppycrawl.com/dtds/suppressions_1_1.dtd ([https](https://www.puppycrawl.com/dtds/suppressions_1_1.dtd) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://EditorConfig.org with 1 occurrences migrated to:  
  https://EditorConfig.org ([https](https://EditorConfig.org) result 200).
* [ ] http://asciidoctor.org with 1 occurrences migrated to:  
  https://asciidoctor.org ([https](https://asciidoctor.org) result 200).
* [ ] http://example.com with 2 occurrences migrated to:  
  https://example.com ([https](https://example.com) result 200).
* [ ] http://github.com/ with 1 occurrences migrated to:  
  https://github.com/ ([https](https://github.com/) result 200).
* [ ] http://projects.spring.io/spring-cloud/ with 1 occurrences migrated to:  
  https://projects.spring.io/spring-cloud/ ([https](https://projects.spring.io/spring-cloud/) result 200).
* [ ] http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html with 2 occurrences migrated to:  
  https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html ([https](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) result 200).
* [ ] http://plugins.jetbrains.com/plugin/6546 with 2 occurrences migrated to:  
  https://plugins.jetbrains.com/plugin/6546 ([https](https://plugins.jetbrains.com/plugin/6546) result 301).
* [ ] http://raw.github.com/ with 1 occurrences migrated to:  
  https://raw.github.com/ ([https](https://raw.github.com/) result 301).
* [ ] http://service.com with 1 occurrences migrated to:  
  https://service.com ([https](https://service.com) result 301).
* [ ] http://eclipse.org with 1 occurrences migrated to:  
  https://eclipse.org ([https](https://eclipse.org) result 302).
* [ ] http://eclipse.org/m2e/ with 2 occurrences migrated to:  
  https://eclipse.org/m2e/ ([https](https://eclipse.org/m2e/) result 302).
* [ ] http://www.springsource.com/developer/sts with 1 occurrences migrated to:  
  https://www.springsource.com/developer/sts ([https](https://www.springsource.com/developer/sts) result 302).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 11 occurrences
* http://localhost:8080/ with 1 occurrences
* http://localhost:8081/ with 1 occurrences