### PR TITLE
Overridable QueryMapEncoder

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -128,6 +128,7 @@ Spring Cloud Netflix _does not_ provide the following beans by default for feign
 * `Request.Options`
 * `Collection<RequestInterceptor>`
 * `SetterFactory`
+* `QueryMapEncoder`
 
 Creating a bean of one of those type and placing it in a `@FeignClient` configuration (such as `FooConfiguration` above) allows you to override each one of the beans described.  Example:
 
@@ -487,3 +488,5 @@ public class DemoTemplate {
     String demoEndpoint(@SpringQueryMap Params params);
 }
 ----
+
+If you need more control over the generated query parameter map, you can implement a custom `QueryMapEncoder` bean.

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
@@ -23,6 +23,7 @@ import feign.Client;
 import feign.Contract;
 import feign.Feign;
 import feign.Logger;
+import feign.QueryMapEncoder;
 import feign.Request;
 import feign.RequestInterceptor;
 import feign.Retryer;
@@ -147,7 +148,10 @@ class FeignClientFactoryBean
 		if (requestInterceptors != null) {
 			builder.requestInterceptors(requestInterceptors.values());
 		}
-
+		QueryMapEncoder queryMapEncoder = getOptional(context, QueryMapEncoder.class);
+		if (queryMapEncoder != null) {
+			builder.queryMapEncoder(queryMapEncoder);
+		}
 		if (this.decode404) {
 			builder.decode404();
 		}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientOverrideDefaultsTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientOverrideDefaultsTests.java
@@ -19,6 +19,7 @@ package org.springframework.cloud.openfeign;
 import feign.Contract;
 import feign.Feign;
 import feign.Logger;
+import feign.QueryMapEncoder;
 import feign.Request;
 import feign.RequestInterceptor;
 import feign.RequestLine;
@@ -30,6 +31,7 @@ import feign.codec.Encoder;
 import feign.codec.ErrorDecoder;
 import feign.hystrix.HystrixFeign;
 import feign.optionals.OptionalDecoder;
+import feign.querymap.BeanQueryMapEncoder;
 import feign.slf4j.Slf4jLogger;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -134,6 +136,14 @@ public class FeignClientOverrideDefaultsTests {
 	}
 
 	@Test
+	public void overrideQueryMapEncoder() {
+		QueryMapEncoder.Default.class
+				.cast(this.context.getInstance("foo", QueryMapEncoder.class));
+		BeanQueryMapEncoder.class
+				.cast(this.context.getInstance("bar", QueryMapEncoder.class));
+	}
+
+	@Test
 	public void addRequestInterceptor() {
 		assertThat(this.context.getInstances("foo", RequestInterceptor.class).size())
 				.isEqualTo(1);
@@ -141,7 +151,8 @@ public class FeignClientOverrideDefaultsTests {
 				.isEqualTo(2);
 	}
 
-	@FeignClient(name = "foo", url = "https://foo", configuration = FooConfiguration.class)
+	@FeignClient(name = "foo", url = "https://foo",
+			configuration = FooConfiguration.class)
 	interface FooClient {
 
 		@RequestLine("GET /")
@@ -149,7 +160,8 @@ public class FeignClientOverrideDefaultsTests {
 
 	}
 
-	@FeignClient(name = "bar", url = "https://bar", configuration = BarConfiguration.class)
+	@FeignClient(name = "bar", url = "https://bar",
+			configuration = BarConfiguration.class)
 	interface BarClient {
 
 		@RequestMapping(value = "/", method = RequestMethod.GET)
@@ -201,6 +213,11 @@ public class FeignClientOverrideDefaultsTests {
 			return HystrixFeign.builder();
 		}
 
+		@Bean
+		public QueryMapEncoder queryMapEncoder() {
+			return new feign.QueryMapEncoder.Default();
+		}
+
 	}
 
 	public static class BarConfiguration {
@@ -228,6 +245,11 @@ public class FeignClientOverrideDefaultsTests {
 		@Bean
 		RequestInterceptor feignRequestInterceptor() {
 			return new BasicAuthRequestInterceptor("user", "pass");
+		}
+
+		@Bean
+		public QueryMapEncoder queryMapEncoder() {
+			return new BeanQueryMapEncoder();
 		}
 
 	}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientOverrideDefaultsTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientOverrideDefaultsTests.java
@@ -151,8 +151,7 @@ public class FeignClientOverrideDefaultsTests {
 				.isEqualTo(2);
 	}
 
-	@FeignClient(name = "foo", url = "https://foo",
-			configuration = FooConfiguration.class)
+	@FeignClient(name = "foo", url = "https://foo", configuration = FooConfiguration.class)
 	interface FooClient {
 
 		@RequestLine("GET /")
@@ -160,8 +159,7 @@ public class FeignClientOverrideDefaultsTests {
 
 	}
 
-	@FeignClient(name = "bar", url = "https://bar",
-			configuration = BarConfiguration.class)
+	@FeignClient(name = "bar", url = "https://bar", configuration = BarConfiguration.class)
 	interface BarClient {
 
 		@RequestMapping(value = "/", method = RequestMethod.GET)


### PR DESCRIPTION
Added the possibility to override the default QueryMapEncoder by defining a custom one in the ApplicationContext.