### PR TITLE
FeignClientBuilder.Builder should always return the generic builder

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientBuilder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientBuilder.java
@@ -61,43 +61,42 @@ public class FeignClientBuilder {
 					.fallbackFactory(void.class);
 		}
 
-		public Builder url(final String url) {
+		public Builder<T> url(final String url) {
 			this.feignClientFactoryBean.setUrl(FeignClientsRegistrar.getUrl(url));
 			return this;
 		}
 
-		public Builder contextId(final String contextId) {
+		public Builder<T> contextId(final String contextId) {
 			this.feignClientFactoryBean.setContextId(contextId);
 			return this;
 		}
 
-		public Builder path(final String path) {
+		public Builder<T> path(final String path) {
 			this.feignClientFactoryBean.setPath(FeignClientsRegistrar.getPath(path));
 			return this;
 		}
 
-		public Builder decode404(final boolean decode404) {
+		public Builder<T> decode404(final boolean decode404) {
 			this.feignClientFactoryBean.setDecode404(decode404);
 			return this;
 		}
 
-		public Builder fallback(final Class<T> fallback) {
+		public Builder<T> fallback(final Class<?> fallback) {
 			FeignClientsRegistrar.validateFallback(fallback);
 			this.feignClientFactoryBean.setFallback(fallback);
 			return this;
 		}
 
-		public Builder fallbackFactory(final Class<T> fallbackFactory) {
+		public Builder<T> fallbackFactory(final Class<?> fallbackFactory) {
 			FeignClientsRegistrar.validateFallbackFactory(fallbackFactory);
 			this.feignClientFactoryBean.setFallbackFactory(fallbackFactory);
 			return this;
 		}
 
 		/**
-		 * @param <T> the target type of the Feign client to be created
 		 * @return the created Feign client
 		 */
-		public <T> T build() {
+		public T build() {
 			return this.feignClientFactoryBean.getTarget();
 		}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientBuilderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientBuilderTests.java
@@ -128,12 +128,13 @@ public class FeignClientBuilderTests {
 		final FeignClientBuilder.Builder builder = this.feignClientBuilder
 				.forType(FeignClientBuilderTests.class, "TestClient").decode404(true)
 				.fallback(Object.class).fallbackFactory(Object.class).path("Path/")
-				.url("Url/");
+				.url("Url/").contextId("TestContext");
 
 		// then:
 		assertFactoryBeanField(builder, "applicationContext", this.applicationContext);
 		assertFactoryBeanField(builder, "type", FeignClientBuilderTests.class);
 		assertFactoryBeanField(builder, "name", "TestClient");
+		assertFactoryBeanField(builder, "contextId", "TestContext");
 
 		// and:
 		assertFactoryBeanField(builder, "url", "http://Url/");


### PR DESCRIPTION
Hi,
in the current version the FeignClientBuilder.Builder is return always it's raw type and not the generic one. This leads to many unckeck cast warnings or type mismatch errors.

With the current version the following code, will produce an type mismatch error
```
@Bean
    public DummyClass dummyClass() {
        return feignClientBuilder.forType(DummyClass.class, "dummyClass")
            .url("URL").build();
    }
//Error:(25, 57) java: incompatible types: java.lang.Object cannot be converted to DummyClass
```
The problem is, that the method url is returning **Builder** instead of **Builder&lt;T&gt;**. 

I also changed the parameter for the two methods fallback & fallbackFactory to **Class&lt;?&gt;** (as mention in #184), so the code is backward-compatible. Also the BuilderTest will set the fallback to Object.
There is already a discussion about the two fallback methods (#197 and #184) and we should discuss about these methods there.
The intent of this pullrequest is only to make the builder return is generic implementation, so we can avoid casting it to the correct class.

Feel free to ask or change something in the code.
Cheers,
Robert