### PR TITLE
Update Javadoc for FeignClient.configuration()

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClient.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClient.java
@@ -85,7 +85,7 @@ public @interface FeignClient {
 	boolean decode404() default false;
 
 	/**
-	 * A custom <code>@Configuration</code> for the feign client. Can contain override
+	 * A custom configuration class for the feign client. Can contain override
 	 * <code>@Bean</code> definition for the pieces that make up the client, for instance
 	 * {@link feign.codec.Decoder}, {@link feign.codec.Encoder}, {@link feign.Contract}.
 	 *


### PR DESCRIPTION
Referring to <code>@Configuration</code> is a bit confusing. The referred class does not need the annotation, and actually using it could cause issues due the class additionally getting picked up by the component scan.