### PR TITLE
Switch to medium resource class in circleci.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,6 @@ jobs:
     branches:
       ignore:
         - gh-pages # list of branches to ignore
-    resource_class: large
     steps:
       - checkout
       - restore_cache:


### PR DESCRIPTION
Attempted fix for: "execution not authorized due to: free-plan-resource-class-unavailable"
https://circleci.com/gh/spring-cloud/spring-cloud-openfeign/1225?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link