### PR TITLE
SpringDecoder should respect 'decode404' settings

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringDecoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringDecoder.java
@@ -24,6 +24,7 @@ import java.lang.reflect.WildcardType;
 
 import feign.FeignException;
 import feign.Response;
+import feign.Util;
 import feign.codec.DecodeException;
 import feign.codec.Decoder;
 
@@ -50,6 +51,9 @@ public class SpringDecoder implements Decoder {
 	@Override
 	public Object decode(final Response response, Type type)
 			throws IOException, FeignException {
+		if (response.status() == 404) {
+			return Util.emptyValueOf(type);
+		}
 		if (type instanceof Class || type instanceof ParameterizedType
 				|| type instanceof WildcardType) {
 			@SuppressWarnings({ "unchecked", "rawtypes" })


### PR DESCRIPTION
'decode404' is not clearly defined, but I think that for response 404, Feign client should return `Optional.empty()` or `null`.

`Optional` case is implemented correctly, but second case was wrong - `SpringDecoder` tried construct object basing on response body instead just return `null`.

