### PR TITLE
Changing DefaultGzipDecoder's charset to UTF-8

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -429,13 +429,13 @@ feign.compression.request.min-request-size=2048
 
 These properties allow you to be selective about the compressed media types and minimum request threshold length.
 
-For http clients except OkHttpClient, default gzip decoder can be enabled to decode gzip response in ISO-8859-1 encoding:
+For http clients except OkHttpClient, default gzip decoder can be enabled to decode gzip response in UTF-8 encoding:
 
 [source,java]
----
+----
 feign.compression.response.enabled=true
 feign.compression.response.useGzipDecoder=true
----
+----
 
 === Feign logging
 

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/DefaultGzipDecoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/DefaultGzipDecoder.java
@@ -20,12 +20,12 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Type;
+import java.nio.charset.StandardCharsets;
 import java.util.Collection;
 import java.util.zip.GZIPInputStream;
 
 import feign.FeignException;
 import feign.Response;
-import feign.Util;
 import feign.codec.Decoder;
 
 import org.springframework.cloud.openfeign.encoding.HttpEncoding;
@@ -72,7 +72,7 @@ public class DefaultGzipDecoder implements Decoder {
 		try (GZIPInputStream gzipInputStream = new GZIPInputStream(
 				response.body().asInputStream());
 				BufferedReader reader = new BufferedReader(
-						new InputStreamReader(gzipInputStream, Util.ISO_8859_1))) {
+						new InputStreamReader(gzipInputStream, StandardCharsets.UTF_8))) {
 			String outputString = "";
 			String line;
 			while ((line = reader.readLine()) != null) {

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/DefaultGzipDecoderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/DefaultGzipDecoderTests.java
@@ -90,6 +90,18 @@ public class DefaultGzipDecoderTests extends FeignClientFactoryBean {
 		assertThat(hello).as("null hello didn't match").isEqualTo(null);
 	}
 
+	@Test
+	public void testCharsetDecompress() {
+		ResponseEntity<Hello> response = testClient().getUtf8Response();
+		assertThat(response).as("response was null").isNotNull();
+		assertThat(response.getStatusCode()).as("wrong status code")
+				.isEqualTo(HttpStatus.OK);
+		Hello hello = response.getBody();
+		assertThat(hello).as("hello was null").isNotNull();
+		assertThat(hello).as("utf8 hello didn't match")
+				.isEqualTo(new Hello("안녕하세요 means Hello in Korean"));
+	}
+
 	private static class Hello {
 
 		private String message;
@@ -136,6 +148,9 @@ public class DefaultGzipDecoderTests extends FeignClientFactoryBean {
 		@GetMapping("/nullGzipResponse")
 		ResponseEntity<Hello> getNullResponse();
 
+		@GetMapping("/utf8Response")
+		ResponseEntity<Hello> getUtf8Response();
+
 	}
 
 	@Configuration(proxyBeanMethods = false)
@@ -152,6 +167,11 @@ public class DefaultGzipDecoderTests extends FeignClientFactoryBean {
 		@Override
 		public ResponseEntity<Hello> getNullResponse() {
 			return ResponseEntity.ok(null);
+		}
+
+		@Override
+		public ResponseEntity<Hello> getUtf8Response() {
+			return ResponseEntity.ok(new Hello("안녕하세요 means Hello in Korean"));
 		}
 
 	}


### PR DESCRIPTION
Problem Statement:
 - When tested with a UTF-8, DefaultGzipDecoder returned with garbage data because it is using latin-1 charsets.
 - The added test case in the PR proves such case.

Suggestion:
 - [SpringEncoder.java](https://github.com/spring-cloud/spring-cloud-openfeign/blob/1ce5ca1ba83a96036efa105d1fedfb1a72f0303f/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringEncoder.java#L136) uses UTF-8 by default  So it makes sense to use UTF-8 when decoding.