### PR TITLE
Support for configuring the ExceptionPropagationPolicy

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 
 import feign.Client;
 import feign.Contract;
+import feign.ExceptionPropagationPolicy;
 import feign.Feign;
 import feign.Logger;
 import feign.QueryMapEncoder;
@@ -155,6 +156,11 @@ class FeignClientFactoryBean
 		if (this.decode404) {
 			builder.decode404();
 		}
+		ExceptionPropagationPolicy exceptionPropagationPolicy = getOptional(context,
+				ExceptionPropagationPolicy.class);
+		if (exceptionPropagationPolicy != null) {
+			builder.exceptionPropagationPolicy(exceptionPropagationPolicy);
+		}
 	}
 
 	protected void configureUsingProperties(
@@ -208,6 +214,10 @@ class FeignClientFactoryBean
 
 		if (Objects.nonNull(config.getContract())) {
 			builder.contract(getOrInstantiate(config.getContract()));
+		}
+
+		if (Objects.nonNull(config.getExceptionPropagationPolicy())) {
+			builder.exceptionPropagationPolicy(config.getExceptionPropagationPolicy());
 		}
 	}
 

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientProperties.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientProperties.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Objects;
 
 import feign.Contract;
+import feign.ExceptionPropagationPolicy;
 import feign.Logger;
 import feign.RequestInterceptor;
 import feign.Retryer;
@@ -111,6 +112,8 @@ public class FeignClientProperties {
 
 		private Class<Contract> contract;
 
+		private ExceptionPropagationPolicy exceptionPropagationPolicy;
+
 		public Logger.Level getLoggerLevel() {
 			return this.loggerLevel;
 		}
@@ -192,6 +195,15 @@ public class FeignClientProperties {
 			this.contract = contract;
 		}
 
+		public ExceptionPropagationPolicy getExceptionPropagationPolicy() {
+			return exceptionPropagationPolicy;
+		}
+
+		public void setExceptionPropagationPolicy(
+				ExceptionPropagationPolicy exceptionPropagationPolicy) {
+			this.exceptionPropagationPolicy = exceptionPropagationPolicy;
+		}
+
 		@Override
 		public boolean equals(Object o) {
 			if (this == o) {
@@ -210,14 +222,17 @@ public class FeignClientProperties {
 					&& Objects.equals(this.decode404, that.decode404)
 					&& Objects.equals(this.encoder, that.encoder)
 					&& Objects.equals(this.decoder, that.decoder)
-					&& Objects.equals(this.contract, that.contract);
+					&& Objects.equals(this.contract, that.contract)
+					&& Objects.equals(this.exceptionPropagationPolicy,
+							that.exceptionPropagationPolicy);
 		}
 
 		@Override
 		public int hashCode() {
 			return Objects.hash(this.loggerLevel, this.connectTimeout, this.readTimeout,
 					this.retryer, this.errorDecoder, this.requestInterceptors,
-					this.decode404, this.encoder, this.decoder, this.contract);
+					this.decode404, this.encoder, this.decoder, this.contract,
+					this.exceptionPropagationPolicy);
 		}
 
 	}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientOverrideDefaultsTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientOverrideDefaultsTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.openfeign;
 
 import feign.Contract;
+import feign.ExceptionPropagationPolicy;
 import feign.Feign;
 import feign.Logger;
 import feign.QueryMapEncoder;
@@ -151,6 +152,14 @@ public class FeignClientOverrideDefaultsTests {
 				.isEqualTo(2);
 	}
 
+	@Test
+	public void exceptionPropagationPolicy() {
+		assertThat(this.context.getInstances("foo", ExceptionPropagationPolicy.class))
+				.isNull();
+		assertThat(this.context.getInstances("bar", ExceptionPropagationPolicy.class))
+				.containsValues(ExceptionPropagationPolicy.UNWRAP);
+	}
+
 	@FeignClient(name = "foo", url = "https://foo",
 			configuration = FooConfiguration.class)
 	interface FooClient {
@@ -250,6 +259,11 @@ public class FeignClientOverrideDefaultsTests {
 		@Bean
 		public QueryMapEncoder queryMapEncoder() {
 			return new BeanQueryMapEncoder();
+		}
+
+		@Bean
+		public ExceptionPropagationPolicy exceptionPropagationPolicy() {
+			return ExceptionPropagationPolicy.UNWRAP;
 		}
 
 	}

--- a/spring-cloud-openfeign-core/src/test/resources/feign-properties.properties
+++ b/spring-cloud-openfeign-core/src/test/resources/feign-properties.properties
@@ -13,3 +13,6 @@ feign.client.config.foo.requestInterceptors[1]=org.springframework.cloud.openfei
 feign.client.config.bar.connectTimeout=1000
 feign.client.config.bar.readTimeout=1000
 feign.client.config.form.encoder=org.springframework.cloud.openfeign.FeignClientUsingPropertiesTests.FormEncoder
+feign.client.config.unwrap.connectTimeout=1000
+feign.client.config.unwrap.readTimeout=1000
+feign.client.config.unwrap.exceptionPropagationPolicy=unwrap


### PR DESCRIPTION
Can be configured via properties or as a `@Bean`.

Fixes GH-243