### PR TITLE
Define custom AnnotatedParameterProcessor while keeping defaults

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -110,13 +110,9 @@ public class SpringMvcContract extends Contract.BaseContract
 				"Parameter processors can not be null.");
 		Assert.notNull(conversionService, "ConversionService can not be null.");
 
-		List<AnnotatedParameterProcessor> processors;
-		if (!annotatedParameterProcessors.isEmpty()) {
-			processors = new ArrayList<>(annotatedParameterProcessors);
-		}
-		else {
-			processors = getDefaultAnnotatedArgumentsProcessors();
-		}
+		List<AnnotatedParameterProcessor> processors = getDefaultAnnotatedArgumentsProcessors();
+		processors.addAll(annotatedParameterProcessors);
+
 		this.annotatedArgumentProcessors = toAnnotatedArgumentProcessorMap(processors);
 		this.conversionService = conversionService;
 		this.convertingExpanderFactory = new ConvertingExpanderFactory(conversionService);


### PR DESCRIPTION
Keep default ```AnnotatedParameterProcessor```s while defining custom ones.

Fixes gh-111