### PR TITLE
exposed client factory bean and targeter

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientBuilder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientBuilder.java
@@ -27,6 +27,7 @@ import org.springframework.context.ApplicationContext;
  * {@link FeignClient} annotation.
  *
  * @author Sven Döring
+ * @author Matt King
  */
 public class FeignClientBuilder {
 
@@ -40,6 +41,11 @@ public class FeignClientBuilder {
 		return new Builder<>(this.applicationContext, type, name);
 	}
 
+	public <T> Builder<T> forType(final Class<T> type,
+			final FeignClientFactoryBean clientFactoryBean, final String name) {
+		return new Builder<>(this.applicationContext, clientFactoryBean, type, name);
+	}
+
 	/**
 	 * Builder of feign targets.
 	 *
@@ -51,7 +57,13 @@ public class FeignClientBuilder {
 
 		private Builder(final ApplicationContext applicationContext, final Class<T> type,
 				final String name) {
-			this.feignClientFactoryBean = new FeignClientFactoryBean();
+			this(applicationContext, new FeignClientFactoryBean(), type, name);
+		}
+
+		private Builder(final ApplicationContext applicationContext,
+				final FeignClientFactoryBean clientFactoryBean, final Class<T> type,
+				final String name) {
+			this.feignClientFactoryBean = clientFactoryBean;
 
 			this.feignClientFactoryBean.setApplicationContext(applicationContext);
 			this.feignClientFactoryBean.setType(type);

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
@@ -51,7 +51,7 @@ import org.springframework.util.StringUtils;
  * @author Eko Kurniawan Khannedy
  * @author Gregor Zurowski
  */
-class FeignClientFactoryBean
+public class FeignClientFactoryBean
 		implements FactoryBean<Object>, InitializingBean, ApplicationContextAware {
 
 	/***********************************

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/Targeter.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/Targeter.java
@@ -22,7 +22,7 @@ import feign.Target;
 /**
  * @author Spencer Gibb
  */
-interface Targeter {
+public interface Targeter {
 
 	<T> T target(FeignClientFactoryBean factory, Feign.Builder feign,
 			FeignContext context, Target.HardCodedTarget<T> target);

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientBuilderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientBuilderTests.java
@@ -148,6 +148,31 @@ public class FeignClientBuilderTests {
 	}
 
 	@Test
+	public void forType_clientFactoryBeanProvided() {
+		// when:
+		final FeignClientBuilder.Builder builder = this.feignClientBuilder
+				.forType(TestFeignClient.class, new FeignClientFactoryBean(),
+						"TestClient")
+				.decode404(true).fallback(TestFeignClientFallback.class)
+				.fallbackFactory(TestFeignClientFallbackFactory.class).path("Path/")
+				.url("Url/").contextId("TestContext");
+
+		// then:
+		assertFactoryBeanField(builder, "applicationContext", this.applicationContext);
+		assertFactoryBeanField(builder, "type", TestFeignClient.class);
+		assertFactoryBeanField(builder, "name", "TestClient");
+		assertFactoryBeanField(builder, "contextId", "TestContext");
+
+		// and:
+		assertFactoryBeanField(builder, "url", "http://Url/");
+		assertFactoryBeanField(builder, "path", "/Path");
+		assertFactoryBeanField(builder, "decode404", true);
+		assertFactoryBeanField(builder, "fallback", TestFeignClientFallback.class);
+		assertFactoryBeanField(builder, "fallbackFactory",
+				TestFeignClientFallbackFactory.class);
+	}
+
+	@Test
 	public void forType_build() {
 		// given:
 		Mockito.when(this.applicationContext.getBean(FeignContext.class))


### PR DESCRIPTION
Exposed ```Targeter``` and ```FeignClientFactoryBean``` to public.

I did not add ```@Autowired``` to ```FeignClientFactoryBean``` in ```FeignClientBuilder.Builder``` as suggested in gh-278. I had some concerns that there may be some side effects from that since the builder is expecting a new instance each time. Instead I overloaded ```FeignClientBuilder.forType()``` so a instance of ```FeignClientFactoryBean``` could be provided when needed.

fixes gh-278
fixes gh-240