### PR TITLE
add customizer for feign builder

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignBuilderCustomizer.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignBuilderCustomizer.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign;
+
+import feign.Feign;
+
+import org.springframework.security.config.Customizer;
+
+/**
+ * Allows application to customize the Feign builder.
+ *
+ * @author Matt King
+ */
+public interface FeignBuilderCustomizer extends Customizer<Feign.Builder> {
+
+}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignBuilderCustomizer.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignBuilderCustomizer.java
@@ -18,13 +18,14 @@ package org.springframework.cloud.openfeign;
 
 import feign.Feign;
 
-import org.springframework.security.config.Customizer;
-
 /**
  * Allows application to customize the Feign builder.
  *
  * @author Matt King
  */
-public interface FeignBuilderCustomizer extends Customizer<Feign.Builder> {
+@FunctionalInterface
+public interface FeignBuilderCustomizer {
+
+	void customize(Feign.Builder builder);
 
 }

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
@@ -99,12 +99,21 @@ class FeignClientFactoryBean
 		// @formatter:on
 
 		configureFeign(context, builder);
-		context.getInstances(contextId, FeignBuilderCustomizer.class).values().stream()
-				.sorted(AnnotationAwareOrderComparator.INSTANCE)
-				.forEach(feignBuilderCustomizer -> feignBuilderCustomizer
-						.customize(builder));
+		applyBuildCustomizers(context, builder);
 
 		return builder;
+	}
+
+	private void applyBuildCustomizers(FeignContext context, Feign.Builder builder) {
+		Map<String, FeignBuilderCustomizer> customizerMap = context
+				.getInstances(contextId, FeignBuilderCustomizer.class);
+
+		if (customizerMap != null) {
+			customizerMap.values().stream()
+					.sorted(AnnotationAwareOrderComparator.INSTANCE)
+					.forEach(feignBuilderCustomizer -> feignBuilderCustomizer
+							.customize(builder));
+		}
 	}
 
 	protected void configureFeign(FeignContext context, Feign.Builder builder) {

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
@@ -86,8 +86,6 @@ class FeignClientFactoryBean
 	}
 
 	protected Feign.Builder feign(FeignContext context) {
-		Map<String, FeignBuilderCustomizer> customizerMap = context
-				.getInstances(contextId, FeignBuilderCustomizer.class);
 		FeignLoggerFactory loggerFactory = get(context, FeignLoggerFactory.class);
 		Logger logger = loggerFactory.create(this.type);
 
@@ -101,7 +99,8 @@ class FeignClientFactoryBean
 		// @formatter:on
 
 		configureFeign(context, builder);
-		customizerMap.values().stream().sorted(AnnotationAwareOrderComparator.INSTANCE)
+		context.getInstances(contextId, FeignBuilderCustomizer.class).values().stream()
+				.sorted(AnnotationAwareOrderComparator.INSTANCE)
 				.forEach(feignBuilderCustomizer -> feignBuilderCustomizer
 						.customize(builder));
 

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
@@ -84,6 +84,7 @@ class FeignClientFactoryBean
 	}
 
 	protected Feign.Builder feign(FeignContext context) {
+		FeignBuilderCustomizer customizer = get(context, FeignBuilderCustomizer.class);
 		FeignLoggerFactory loggerFactory = get(context, FeignLoggerFactory.class);
 		Logger logger = loggerFactory.create(this.type);
 
@@ -97,6 +98,7 @@ class FeignClientFactoryBean
 		// @formatter:on
 
 		configureFeign(context, builder);
+		customizer.customize(builder);
 
 		return builder;
 	}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -139,13 +139,6 @@ public class FeignClientsConfiguration {
 	}
 
 	@Bean
-	@ConditionalOnMissingBean(FeignBuilderCustomizer.class)
-	public FeignBuilderCustomizer feignBuilderCustomizer() {
-		return (builder) -> {
-		};
-	}
-
-	@Bean
 	@ConditionalOnClass(name = "org.springframework.data.domain.Page")
 	public Module pageJacksonModule() {
 		return new PageJacksonModule();

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -139,6 +139,13 @@ public class FeignClientsConfiguration {
 	}
 
 	@Bean
+	@ConditionalOnMissingBean(FeignBuilderCustomizer.class)
+	public FeignBuilderCustomizer feignBuilderCustomizer() {
+		return (builder) -> {
+		};
+	}
+
+	@Bean
 	@ConditionalOnClass(name = "org.springframework.data.domain.Page")
 	public Module pageJacksonModule() {
 		return new PageJacksonModule();

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignBuilderCustomizerTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignBuilderCustomizerTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign;
+
+import java.lang.reflect.Field;
+
+import feign.Feign;
+import feign.Logger;
+import org.junit.Test;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.util.ReflectionUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author Matt King
+ */
+public class FeignBuilderCustomizerTests {
+
+	@Test
+	public void testDefaultCustomizer() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				FeignBuilderCustomizerTests.SampleConfiguration1.class);
+
+		FeignBuilderCustomizer customizer = context.getBean(FeignBuilderCustomizer.class);
+		assertThat(customizer).as("Null Customizer").isNotNull();
+		assertThat(customizer).as("Not customizer instance")
+				.isInstanceOf(FeignBuilderCustomizer.class);
+
+		context.close();
+	}
+
+	@Test
+	public void testBuilderCustomizer() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+				FeignBuilderCustomizerTests.SampleConfiguration2.class);
+
+		FeignClientFactoryBean clientFactoryBean = context
+				.getBean(FeignClientFactoryBean.class);
+		FeignContext feignContext = context.getBean(FeignContext.class);
+
+		Feign.Builder builder = clientFactoryBean.feign(feignContext);
+		assertFeignBuilderField(builder, "logLevel", Logger.Level.HEADERS);
+		assertFeignBuilderField(builder, "decode404", true);
+
+		context.close();
+	}
+
+	private void assertFeignBuilderField(Feign.Builder builder, String fieldName,
+			Object expectedValue) {
+		Field builderField = ReflectionUtils.findField(Feign.Builder.class, fieldName);
+		ReflectionUtils.makeAccessible(builderField);
+
+		Object value = ReflectionUtils.getField(builderField, builder);
+		assertThat(value).as("Expected value for the field '" + fieldName + "':")
+				.isEqualTo(expectedValue);
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(FeignClientsConfiguration.class)
+	protected static class SampleConfiguration1 {
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@Import(FeignClientsConfiguration.class)
+	protected static class SampleConfiguration2 {
+
+		@Bean
+		FeignContext feignContext() {
+			return new FeignContext();
+		}
+
+		@Bean
+		FeignClientProperties feignClientProperties() {
+			return new FeignClientProperties();
+		}
+
+		@Bean
+		FeignBuilderCustomizer feignBuilderCustomizer() {
+			return builder -> {
+				builder.logLevel(Logger.Level.HEADERS);
+				builder.decode404();
+			};
+		}
+
+		@Bean
+		FeignClientFactoryBean feignClientFactoryBean() {
+			FeignClientFactoryBean feignClientFactoryBean = new FeignClientFactoryBean();
+			feignClientFactoryBean.setContextId("test");
+			feignClientFactoryBean.setName("test");
+			feignClientFactoryBean.setType(FeignClientFactoryTests.TestType.class);
+			feignClientFactoryBean.setPath("");
+			feignClientFactoryBean.setUrl("http://some.absolute.url");
+			return feignClientFactoryBean;
+		}
+
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignBuilderCustomizerTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignBuilderCustomizerTests.java
@@ -37,19 +37,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class FeignBuilderCustomizerTests {
 
 	@Test
-	public void testDefaultCustomizer() {
-		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
-				FeignBuilderCustomizerTests.SampleConfiguration1.class);
-
-		FeignBuilderCustomizer customizer = context.getBean(FeignBuilderCustomizer.class);
-		assertThat(customizer).as("Null Customizer").isNotNull();
-		assertThat(customizer).as("Not customizer instance")
-				.isInstanceOf(FeignBuilderCustomizer.class);
-
-		context.close();
-	}
-
-	@Test
 	public void testBuilderCustomizer() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 				FeignBuilderCustomizerTests.SampleConfiguration2.class);
@@ -99,12 +86,6 @@ public class FeignBuilderCustomizerTests {
 		feignClientFactoryBean.setPath("");
 		feignClientFactoryBean.setUrl("http://some.absolute.url");
 		return feignClientFactoryBean;
-	}
-
-	@Configuration(proxyBeanMethods = false)
-	@Import(FeignClientsConfiguration.class)
-	protected static class SampleConfiguration1 {
-
 	}
 
 	@Configuration(proxyBeanMethods = false)


### PR DESCRIPTION
Adds a ```Customizer``` for ```Feign.Builder``` to allow customization. 

When used ```FeignBuilderCustomizer``` will override other configurations.

Effects ```@FeignClient``` and ```FeignClientBuilder``` building.

fixes gh-244