### PR TITLE
Allow empty list for @RequestPart List<MultipartFile>

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.openfeign;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.Module;
@@ -25,8 +26,11 @@ import feign.Feign;
 import feign.Logger;
 import feign.Retryer;
 import feign.codec.Decoder;
+import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import feign.form.MultipartFormContentProcessor;
+import feign.form.multipart.Output;
+import feign.form.multipart.Writer;
 import feign.form.spring.SpringFormEncoder;
 import feign.optionals.OptionalDecoder;
 
@@ -184,6 +188,17 @@ public class FeignClientsConfiguration {
 
 			MultipartFormContentProcessor processor = (MultipartFormContentProcessor) getContentProcessor(
 					MULTIPART);
+			processor.addFirstWriter(new Writer() {
+				@Override
+				public boolean isApplicable(Object value) {
+					return value instanceof Collection && ((Collection) value).isEmpty();
+				}
+
+				@Override
+				public void write(Output output, String boundary, String key,
+						Object value) throws EncodeException {
+				}
+			});
 			processor.addFirstWriter(formWriter);
 		}
 

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -17,7 +17,6 @@
 package org.springframework.cloud.openfeign;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 import com.fasterxml.jackson.databind.Module;
@@ -26,11 +25,8 @@ import feign.Feign;
 import feign.Logger;
 import feign.Retryer;
 import feign.codec.Decoder;
-import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import feign.form.MultipartFormContentProcessor;
-import feign.form.multipart.Output;
-import feign.form.multipart.Writer;
 import feign.form.spring.SpringFormEncoder;
 import feign.optionals.OptionalDecoder;
 
@@ -188,17 +184,6 @@ public class FeignClientsConfiguration {
 
 			MultipartFormContentProcessor processor = (MultipartFormContentProcessor) getContentProcessor(
 					MULTIPART);
-			processor.addFirstWriter(new Writer() {
-				@Override
-				public boolean isApplicable(Object value) {
-					return value instanceof Collection && ((Collection) value).isEmpty();
-				}
-
-				@Override
-				public void write(Output output, String boundary, String key,
-						Object value) throws EncodeException {
-				}
-			});
 			processor.addFirstWriter(formWriter);
 		}
 

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/EmptyCollectionWriter.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/EmptyCollectionWriter.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.support;
+
+import java.util.Collection;
+
+import feign.codec.EncodeException;
+import feign.form.multipart.Output;
+import feign.form.multipart.Writer;
+
+/**
+ * @author Darren Foong
+ */
+public class EmptyCollectionWriter implements Writer {
+
+	@Override
+	public boolean isApplicable(Object value) {
+		return value instanceof Collection && ((Collection) value).isEmpty();
+	}
+
+	@Override
+	public void write(Output output, String boundary, String key, Object value)
+			throws EncodeException {
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringEncoder.java
@@ -29,6 +29,7 @@ import feign.Request;
 import feign.RequestTemplate;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
+import feign.form.MultipartFormContentProcessor;
 import feign.form.spring.SpringFormEncoder;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -46,6 +47,7 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter;
 import org.springframework.web.multipart.MultipartFile;
 
+import static feign.form.ContentType.MULTIPART;
 import static org.springframework.cloud.openfeign.support.FeignUtils.getHeaders;
 import static org.springframework.cloud.openfeign.support.FeignUtils.getHttpHeaders;
 
@@ -67,12 +69,20 @@ public class SpringEncoder implements Encoder {
 	public SpringEncoder(ObjectFactory<HttpMessageConverters> messageConverters) {
 		this.springFormEncoder = new SpringFormEncoder();
 		this.messageConverters = messageConverters;
+
+		MultipartFormContentProcessor processor = (MultipartFormContentProcessor) springFormEncoder
+				.getContentProcessor(MULTIPART);
+		processor.addFirstWriter(new EmptyCollectionWriter());
 	}
 
 	public SpringEncoder(SpringFormEncoder springFormEncoder,
 			ObjectFactory<HttpMessageConverters> messageConverters) {
 		this.springFormEncoder = springFormEncoder;
 		this.messageConverters = messageConverters;
+
+		MultipartFormContentProcessor processor = (MultipartFormContentProcessor) springFormEncoder
+				.getContentProcessor(MULTIPART);
+		processor.addFirstWriter(new EmptyCollectionWriter());
 	}
 
 	@Override

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/ValidFeignClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/ValidFeignClientTests.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -350,11 +351,13 @@ public class ValidFeignClientTests {
 	}
 
 	@Test
-	public void testRequestPartWithEmptyListOfPojosAndEmptyListOfMultipartFiles() {
-		// String response = this.multipartClient
-		// .requestPartListOfPojosAndListOfMultipartFiles(Collections.emptyList(),
-		// Collections.emptyList());
-		// assertThat(response).isNull();
+	public void testRequestPartWithListOfPojosAndEmptyListOfMultipartFiles() {
+		Hello pojo1 = new Hello(HELLO_WORLD_1);
+		Hello pojo2 = new Hello(OI_TERRA_2);
+		String response = this.multipartClient
+				.requestPartListOfPojosAndListOfMultipartFiles(
+						Arrays.asList(pojo1, pojo2), Collections.emptyList());
+		assertThat(response).isEqualTo("hello world 1oi terra 2");
 	}
 
 	@Test
@@ -826,9 +829,8 @@ public class ValidFeignClientTests {
 				consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
 				produces = MediaType.TEXT_PLAIN_VALUE)
 		String requestPartListOfPojosAndListOfMultipartFiles(
-				@RequestPart(value = "pojos", required = false) List<Hello> pojos,
-				@RequestPart(value = "files",
-						required = false) List<MultipartFile> files) {
+				@RequestPart("pojos") List<Hello> pojos,
+				@RequestPart("files") List<MultipartFile> files) {
 			StringBuilder result = new StringBuilder();
 
 			for (Hello pojo : pojos) {

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/ValidFeignClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/ValidFeignClientTests.java
@@ -23,6 +23,7 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -347,6 +348,16 @@ public class ValidFeignClientTests {
 		String fileNames = this.multipartClient
 				.requestPartListOfMultipartFilesReturnsFileNames(multipartFiles);
 		assertThat(fileNames).contains("hello1.bin", "hello2.bin");
+	}
+
+	@Test
+	public void testRequestPartWithEmptyListOfMultipartFiles() {
+		String partNames = this.multipartClient
+			.requestPartListOfMultipartFilesReturnsPartNames(Collections.emptyList());
+//		assertThat(partNames).isEqualTo("files,files");
+		String fileNames = this.multipartClient
+			.requestPartListOfMultipartFilesReturnsFileNames(Collections.emptyList());
+//		assertThat(fileNames).contains("hello1.bin", "hello2.bin");
 	}
 
 	@Test

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/ValidFeignClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/ValidFeignClientTests.java
@@ -338,6 +338,19 @@ public class ValidFeignClientTests {
 	}
 
 	@Test
+	public void testRequestPartWithEmptyListOfMultipartFiles() {
+		String partNames = this.multipartClient
+				.requestPartListOfMultipartFilesReturnsPartNames(Collections.emptyList());
+		assertThat(partNames).isNull();
+		String fileNames = this.multipartClient
+				.requestPartListOfMultipartFilesReturnsFileNames(Collections.emptyList());
+		assertThat(fileNames).isNull();
+		String count = this.multipartClient
+				.requestPartListOfMultipartFilesReturnsCount(Collections.emptyList());
+		assertThat(count).isEqualTo("0");
+	}
+
+	@Test
 	public void testRequestPartWithListOfMultipartFiles() {
 		List<MultipartFile> multipartFiles = Arrays.asList(
 				new MockMultipartFile("file1", "hello1.bin", null, "hello".getBytes()),
@@ -348,6 +361,9 @@ public class ValidFeignClientTests {
 		String fileNames = this.multipartClient
 				.requestPartListOfMultipartFilesReturnsFileNames(multipartFiles);
 		assertThat(fileNames).contains("hello1.bin", "hello2.bin");
+		String count = this.multipartClient
+				.requestPartListOfMultipartFilesReturnsCount(multipartFiles);
+		assertThat(count).isEqualTo(Integer.toString(multipartFiles.size()));
 	}
 
 	@Test
@@ -454,6 +470,12 @@ public class ValidFeignClientTests {
 				@RequestPart("world") String world, @RequestPart("pojo1") Hello pojo1,
 				@RequestPart("pojo2") Hello pojo2,
 				@RequestPart("file") MultipartFile file);
+
+		@RequestMapping(method = RequestMethod.POST, path = "/multipartCount",
+				consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+				produces = MediaType.TEXT_PLAIN_VALUE)
+		String requestPartListOfMultipartFilesReturnsCount(
+				@RequestPart("files") List<MultipartFile> files);
 
 		@RequestMapping(method = RequestMethod.POST, path = "/multipartNames",
 				consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
@@ -807,6 +829,14 @@ public class ValidFeignClientTests {
 				@RequestPart("file") MultipartFile file) {
 			return hello + world + pojo1.getMessage() + pojo2.getMessage()
 					+ file.getOriginalFilename();
+		}
+
+		@RequestMapping(method = RequestMethod.POST, path = "/multipartCount",
+				consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+				produces = MediaType.TEXT_PLAIN_VALUE)
+		String requestPartListOfMultipartFilesReturnsCount(
+				@RequestPart("files") List<MultipartFile> files) {
+			return Integer.toString(files.size());
 		}
 
 		@RequestMapping(method = RequestMethod.POST, path = "/multipartNames",

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/ValidFeignClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/valid/ValidFeignClientTests.java
@@ -23,7 +23,6 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
@@ -351,13 +350,11 @@ public class ValidFeignClientTests {
 	}
 
 	@Test
-	public void testRequestPartWithEmptyListOfMultipartFiles() {
-		String partNames = this.multipartClient
-			.requestPartListOfMultipartFilesReturnsPartNames(Collections.emptyList());
-//		assertThat(partNames).isEqualTo("files,files");
-		String fileNames = this.multipartClient
-			.requestPartListOfMultipartFilesReturnsFileNames(Collections.emptyList());
-//		assertThat(fileNames).contains("hello1.bin", "hello2.bin");
+	public void testRequestPartWithEmptyListOfPojosAndEmptyListOfMultipartFiles() {
+		// String response = this.multipartClient
+		// .requestPartListOfPojosAndListOfMultipartFiles(Collections.emptyList(),
+		// Collections.emptyList());
+		// assertThat(response).isNull();
 	}
 
 	@Test
@@ -829,8 +826,9 @@ public class ValidFeignClientTests {
 				consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
 				produces = MediaType.TEXT_PLAIN_VALUE)
 		String requestPartListOfPojosAndListOfMultipartFiles(
-				@RequestPart("pojos") List<Hello> pojos,
-				@RequestPart("files") List<MultipartFile> files) {
+				@RequestPart(value = "pojos", required = false) List<Hello> pojos,
+				@RequestPart(value = "files",
+						required = false) List<MultipartFile> files) {
 			StringBuilder result = new StringBuilder();
 
 			for (Hello pojo : pojos) {


### PR DESCRIPTION
I have a use case where I need to send a list of `MultipartFile`s, but sometimes this list could be empty. Currently, to successfully send an empty list (i.e. the server receives an empty list as a method argument), I need to send `null` instead, which requires me to do a prior `isEmpty()` check.

(It is strange that sending `null` from the client results in an empty list received by the server, but this is documented [here](https://github.com/spring-projects/spring-framework/issues/20876#issuecomment-453465529).)

Sending an empty list now throws an exception:

```
feign.codec.EncodeException: class java.util.Collections$EmptyList is not a type supported by this encoder.
	at feign.codec.Encoder$Default.encode(Encoder.java:94)
	at feign.form.multipart.DelegateWriter.write(DelegateWriter.java:49)
	at feign.form.multipart.AbstractWriter.write(AbstractWriter.java:36)
	at feign.form.MultipartFormContentProcessor.process(MultipartFormContentProcessor.java:87)
	at feign.form.FormEncoder.encode(FormEncoder.java:105)
	at feign.form.spring.SpringFormEncoder.encode(SpringFormEncoder.java:84)
...
```

This PR adds an `EmptyCollectionWriter` to `MultipartFormContentProcessor` in the `SpringFormEncoder`. This `Writer` is a no-op.

It would be ideal to add the `EmptyCollectionWriter` in the [feign-form](https://github.com/OpenFeign/feign-form/) project instead, but that project is relatively inactive.

I also added a new test client endpoint that counts the number of files sent, to make sure that empty lists are not received as `null`, in case Spring Framework changes behaviour in the future.

