### PR TITLE
If this class has been scanned once, skip it and no longer register

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
@@ -226,6 +226,9 @@ class FeignClientsRegistrar
 	private void registerFeignClient(BeanDefinitionRegistry registry,
 			AnnotationMetadata annotationMetadata, Map<String, Object> attributes) {
 		String className = annotationMetadata.getClassName();
+		if (registry.containsBeanDefinition(className)) {
+            return;
+        }
 		BeanDefinitionBuilder definition = BeanDefinitionBuilder
 				.genericBeanDefinition(FeignClientFactoryBean.class);
 		validate(attributes);
@@ -384,12 +387,16 @@ class FeignClientsRegistrar
 
 	private void registerClientConfiguration(BeanDefinitionRegistry registry, Object name,
 			Object configuration) {
+		String beanName = name + "." + FeignClientSpecification.class.getSimpleName();
+		if (registry.containsBeanDefinition(beanName)) {
+            return;
+        }
 		BeanDefinitionBuilder builder = BeanDefinitionBuilder
 				.genericBeanDefinition(FeignClientSpecification.class);
 		builder.addConstructorArgValue(name);
 		builder.addConstructorArgValue(configuration);
 		registry.registerBeanDefinition(
-				name + "." + FeignClientSpecification.class.getSimpleName(),
+				beanName,
 				builder.getBeanDefinition());
 	}
 


### PR DESCRIPTION
Because Fully Qualified Name is used, it is safe. If this class has been scanned once, skip it and no longer register。

I don’t want to set spring.main.allow-bean-definition-overriding=true, because it is possible that the bean will be overridden