### PR TITLE
Fixes gh-391 timeout handling documentation

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -274,6 +274,42 @@ public FeignClientConfigurer feignClientConfigurer() {
 }
 ----
 
+[[timeout-handling]]
+=== Timeout Handling
+
+We can configure timeouts on both default and named client. OpenFeign works with two timeout parameters:
+
+- `connectTimeout` prevents blocking the caller due to the long server processing time.
+- `readTimeout` is applied from the time of connection establishment and is triggered when returning the response takes too long.
+
+NOTE: In case the server is not even running or available at all a packet results in _connection refused_. The communication ends either with an error message or in a fallback. This can happen _before_ the `connectTimeout` is set very low. The time taken to perform a lookup and to receive such a packet causes a significant part of such delay. It is subject to change based on the remote host that involves a DNS lookup.
+
+When Hystrix <<spring-cloud-openfeign#spring-cloud-feign-hystrix,is enabled>> its timeout configuration link:https://github.com/Netflix/Hystrix/wiki/Configuration#execution.isolation.thread.timeoutInMilliseconds[defaults] to 1000 milliseconds hence it might occur before the client timeout as configured above. Increasing such a timeout prevents doing so.
+
+[source,yaml]
+----
+feign:
+  client:
+    config:
+      default:
+        connectTimeout: 5000
+        readTimeout: 5000
+  hystrix:
+    enabled: true
+
+hystrix:
+  command:
+    default:
+      execution:
+        timeout:
+          enabled: true
+        isolation:
+          thread:
+            timeoutInMilliseconds: 60000
+----
+
+NOTE: When Hystrix timeout is enabled and its timeout is set longer than of a feign client, `HystrixTimeoutException` wraps a feign exception. Otherwise, the only difference is the cause exception. The purpose of `HystrixTimeoutException` is to wrap any runtime exception which occurs as first and throw an instance of itself.
+
 === Creating Feign Clients Manually
 
 In some cases it might be necessary to customize your Feign Clients in a way that is not

--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -308,7 +308,7 @@ hystrix:
             timeoutInMilliseconds: 60000
 ----
 
-NOTE: When the Hystrix timeout is enabled and its timeout is set longer than that of a feign client, `HystrixTimeoutException` wraps a feign exception. Otherwise, the only difference is the cause of the exception. The purpose of `HystrixTimeoutException` is to wrap any runtime exception that occurs as first and throw an instance of itself.
+NOTE: When the Hystrix timeout is enabled and its timeout is set longer than that of a feign client, `HystrixTimeoutException` wraps a feign exception. Otherwise, the only difference is the cause of the exception. The purpose of `HystrixTimeoutException` is to wrap any runtime exception that occurs first and throw an instance of itself.
 
 === Creating Feign Clients Manually
 

--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -277,14 +277,14 @@ public FeignClientConfigurer feignClientConfigurer() {
 [[timeout-handling]]
 === Timeout Handling
 
-We can configure timeouts on both default and named client. OpenFeign works with two timeout parameters:
+We can configure timeouts on both the default and the named client. OpenFeign works with two timeout parameters:
 
 - `connectTimeout` prevents blocking the caller due to the long server processing time.
 - `readTimeout` is applied from the time of connection establishment and is triggered when returning the response takes too long.
 
-NOTE: In case the server is not even running or available at all a packet results in _connection refused_. The communication ends either with an error message or in a fallback. This can happen _before_ the `connectTimeout` is set very low. The time taken to perform a lookup and to receive such a packet causes a significant part of such delay. It is subject to change based on the remote host that involves a DNS lookup.
+NOTE: In case the server is not running or available a packet results in _connection refused_. The communication ends either with an error message or in a fallback. This can happen _before_ the `connectTimeout` is set very low. The time taken to perform a lookup and to receive such a packet causes a significant part of this delay. It is subject to change based on the remote host that involves a DNS lookup.
 
-When Hystrix <<spring-cloud-openfeign#spring-cloud-feign-hystrix,is enabled>> its timeout configuration link:https://github.com/Netflix/Hystrix/wiki/Configuration#execution.isolation.thread.timeoutInMilliseconds[defaults] to 1000 milliseconds hence it might occur before the client timeout as configured above. Increasing such a timeout prevents it from happening.
+When Hystrix <<spring-cloud-openfeign#spring-cloud-feign-hystrix,is enabled>>, its timeout configuration link:https://github.com/Netflix/Hystrix/wiki/Configuration#execution.isolation.thread.timeoutInMilliseconds[defaults] to 1000 milliseconds. Hence, it might occur before the client timeout that we configured earlier. Increasing this timeout prevents it from happening.
 
 [source,yaml]
 ----
@@ -308,7 +308,7 @@ hystrix:
             timeoutInMilliseconds: 60000
 ----
 
-NOTE: When Hystrix timeout is enabled and its timeout is set longer than of a feign client, `HystrixTimeoutException` wraps a feign exception. Otherwise, the only difference is the cause exception. The purpose of `HystrixTimeoutException` is to wrap any runtime exception which occurs as first and throw an instance of itself.
+NOTE: When the Hystrix timeout is enabled and its timeout is set longer than that of a feign client, HystrixTimeoutException wraps a feign exception. Otherwise, the only difference is the cause of the exception. The purpose of HystrixTimeoutException is to wrap any runtime exception that occurs as first and throw an instance of itself.
 
 === Creating Feign Clients Manually
 

--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -308,7 +308,7 @@ hystrix:
             timeoutInMilliseconds: 60000
 ----
 
-NOTE: When the Hystrix timeout is enabled and its timeout is set longer than that of a feign client, HystrixTimeoutException wraps a feign exception. Otherwise, the only difference is the cause of the exception. The purpose of HystrixTimeoutException is to wrap any runtime exception that occurs as first and throw an instance of itself.
+NOTE: When the Hystrix timeout is enabled and its timeout is set longer than that of a feign client, `HystrixTimeoutException` wraps a feign exception. Otherwise, the only difference is the cause of the exception. The purpose of HystrixTimeoutException is to wrap any runtime exception that occurs as first and throw an instance of itself.
 
 === Creating Feign Clients Manually
 

--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -308,7 +308,7 @@ hystrix:
             timeoutInMilliseconds: 60000
 ----
 
-NOTE: When the Hystrix timeout is enabled and its timeout is set longer than that of a feign client, `HystrixTimeoutException` wraps a feign exception. Otherwise, the only difference is the cause of the exception. The purpose of HystrixTimeoutException is to wrap any runtime exception that occurs as first and throw an instance of itself.
+NOTE: When the Hystrix timeout is enabled and its timeout is set longer than that of a feign client, `HystrixTimeoutException` wraps a feign exception. Otherwise, the only difference is the cause of the exception. The purpose of `HystrixTimeoutException` is to wrap any runtime exception that occurs as first and throw an instance of itself.
 
 === Creating Feign Clients Manually
 

--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -284,7 +284,7 @@ We can configure timeouts on both default and named client. OpenFeign works with
 
 NOTE: In case the server is not even running or available at all a packet results in _connection refused_. The communication ends either with an error message or in a fallback. This can happen _before_ the `connectTimeout` is set very low. The time taken to perform a lookup and to receive such a packet causes a significant part of such delay. It is subject to change based on the remote host that involves a DNS lookup.
 
-When Hystrix <<spring-cloud-openfeign#spring-cloud-feign-hystrix,is enabled>> its timeout configuration link:https://github.com/Netflix/Hystrix/wiki/Configuration#execution.isolation.thread.timeoutInMilliseconds[defaults] to 1000 milliseconds hence it might occur before the client timeout as configured above. Increasing such a timeout prevents doing so.
+When Hystrix <<spring-cloud-openfeign#spring-cloud-feign-hystrix,is enabled>> its timeout configuration link:https://github.com/Netflix/Hystrix/wiki/Configuration#execution.isolation.thread.timeoutInMilliseconds[defaults] to 1000 milliseconds hence it might occur before the client timeout as configured above. Increasing such a timeout prevents it from happening.
 
 [source,yaml]
 ----

--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -282,7 +282,7 @@ We can configure timeouts on both the default and the named client. OpenFeign wo
 - `connectTimeout` prevents blocking the caller due to the long server processing time.
 - `readTimeout` is applied from the time of connection establishment and is triggered when returning the response takes too long.
 
-NOTE: In case the server is not running or available a packet results in _connection refused_. The communication ends either with an error message or in a fallback. This can happen _before_ the `connectTimeout` is set very low. The time taken to perform a lookup and to receive such a packet causes a significant part of this delay. It is subject to change based on the remote host that involves a DNS lookup.
+NOTE: In case the server is not running or available a packet results in _connection refused_. The communication ends either with an error message or in a fallback. This can happen _before_ the `connectTimeout` if it is set very low. The time taken to perform a lookup and to receive such a packet causes a significant part of this delay. It is subject to change based on the remote host that involves a DNS lookup.
 
 When Hystrix <<spring-cloud-openfeign#spring-cloud-feign-hystrix,is enabled>>, its timeout configuration link:https://github.com/Netflix/Hystrix/wiki/Configuration#execution.isolation.thread.timeoutInMilliseconds[defaults] to 1000 milliseconds. Hence, it might occur before the client timeout that we configured earlier. Increasing this timeout prevents it from happening.
 


### PR DESCRIPTION
This should fix https://github.com/spring-cloud/spring-cloud-openfeign/issues/391

I have created a whole new section as long as I believe the timeout handling configuration is something almost always to be customized by developers. 

Please review it. I am open to leave it as is, move it as a part of another section or create a subsection of an existing one. 