### PR TITLE
Fix for Path variables with / are not url encoded

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientProperties.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientProperties.java
@@ -46,6 +46,12 @@ public class FeignClientProperties {
 
 	private Map<String, FeignClientConfiguration> config = new HashMap<>();
 
+	/**
+	 * Feign clients do not encode slash `/` characters by default. To change this
+	 * behavior, set the `decodeSlash` to `false`.
+	 */
+	private boolean decodeSlash = true;
+
 	public boolean isDefaultToProperties() {
 		return this.defaultToProperties;
 	}
@@ -70,6 +76,14 @@ public class FeignClientProperties {
 		this.config = config;
 	}
 
+	public boolean isDecodeSlash() {
+		return decodeSlash;
+	}
+
+	public void setDecodeSlash(boolean decodeSlash) {
+		this.decodeSlash = decodeSlash;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -80,12 +94,13 @@ public class FeignClientProperties {
 		}
 		FeignClientProperties that = (FeignClientProperties) o;
 		return this.defaultToProperties == that.defaultToProperties
-				&& Objects.equals(this.defaultConfig, that.defaultConfig) && Objects.equals(this.config, that.config);
+				&& Objects.equals(this.defaultConfig, that.defaultConfig) && Objects.equals(this.config, that.config)
+				&& Objects.equals(this.decodeSlash, that.decodeSlash);
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(this.defaultToProperties, this.defaultConfig, this.config);
+		return Objects.hash(this.defaultToProperties, this.defaultConfig, this.config, this.decodeSlash);
 	}
 
 	/**

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -79,6 +79,9 @@ public class FeignClientsConfiguration {
 	@Autowired(required = false)
 	private SpringDataWebProperties springDataWebProperties;
 
+	@Autowired(required = false)
+	private FeignClientProperties feignClientProperties;
+
 	@Bean
 	@ConditionalOnMissingBean
 	public Decoder feignDecoder() {
@@ -109,7 +112,8 @@ public class FeignClientsConfiguration {
 	@Bean
 	@ConditionalOnMissingBean
 	public Contract feignContract(ConversionService feignConversionService) {
-		return new SpringMvcContract(this.parameterProcessors, feignConversionService);
+		boolean decodeSlash = feignClientProperties == null || feignClientProperties.isDecodeSlash();
+		return new SpringMvcContract(this.parameterProcessors, feignConversionService, decodeSlash);
 	}
 
 	@Bean

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -101,6 +101,8 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 
 	private ResourceLoader resourceLoader = new DefaultResourceLoader();
 
+	private boolean decodeSlash;
+
 	public SpringMvcContract() {
 		this(Collections.emptyList());
 	}
@@ -111,6 +113,11 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 
 	public SpringMvcContract(List<AnnotatedParameterProcessor> annotatedParameterProcessors,
 			ConversionService conversionService) {
+		this(annotatedParameterProcessors, conversionService, true);
+	}
+
+	public SpringMvcContract(List<AnnotatedParameterProcessor> annotatedParameterProcessors,
+			ConversionService conversionService, boolean decodeSlash) {
 		Assert.notNull(annotatedParameterProcessors, "Parameter processors can not be null.");
 		Assert.notNull(conversionService, "ConversionService can not be null.");
 
@@ -120,6 +127,8 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 		annotatedArgumentProcessors = toAnnotatedArgumentProcessorMap(processors);
 		this.conversionService = conversionService;
 		convertingExpanderFactory = new ConvertingExpanderFactory(conversionService);
+
+		this.decodeSlash = decodeSlash;
 	}
 
 	private static TypeDescriptor createTypeDescriptor(Method method, int paramIndex) {
@@ -171,6 +180,9 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 						pathValue = "/" + pathValue;
 					}
 					data.template().uri(pathValue);
+					if (data.template().decodeSlash() != decodeSlash) {
+						data.template().decodeSlash(decodeSlash);
+					}
 				}
 			}
 		}
@@ -232,6 +244,9 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 					pathValue = "/" + pathValue;
 				}
 				data.template().uri(pathValue, true);
+				if (data.template().decodeSlash() != decodeSlash) {
+					data.template().decodeSlash(decodeSlash);
+				}
 			}
 		}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/AbstractSpringMvcContractIntegrationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/AbstractSpringMvcContractIntegrationTests.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.support;
+
+import java.nio.charset.Charset;
+
+import feign.Response;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.test.NoSecurityConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.util.SocketUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Abstract class for the integration tests for {@link SpringMvcContract}
+ *
+ * @author Ram Anaswara
+ */
+public class AbstractSpringMvcContractIntegrationTests {
+
+	@BeforeAll
+	public static void beforeClass() {
+		System.setProperty("server.port", String.valueOf(SocketUtils.findAvailableTcpPort()));
+	}
+
+	@AfterAll
+	public static void afterClass() {
+		System.clearProperty("server.port");
+	}
+
+	protected String getUrlQueryParam(Response response) {
+		return response.request().requestTemplate().queries().get("url").stream().findFirst()
+				.orElseThrow(IllegalStateException::new);
+	}
+
+	@FeignClient(name = "test", url = "http://localhost:${server.port}/",
+			configuration = NoCodecsFeignConfiguration.class)
+	interface TestClient {
+
+		@PostMapping("/test")
+		Object sendMessage(@RequestBody String message, @RequestHeader(HttpHeaders.CONTENT_TYPE) String acceptHeader);
+
+		@GetMapping("/get")
+		Object getMessage(@RequestParam String url);
+
+	}
+
+	@Configuration(proxyBeanMethods = false)
+	@EnableFeignClients(clients = TestClient.class)
+	@EnableAutoConfiguration
+	@RestController
+	@Import(NoSecurityConfiguration.class)
+	protected static class Config {
+
+		@PostMapping("/test")
+		Object sendMessage(@RequestBody String message, @RequestHeader(HttpHeaders.CONTENT_TYPE) String acceptHeader) {
+			return message;
+		}
+
+		@GetMapping("/get")
+		Object getMessage(@RequestParam String url) {
+			return url;
+		}
+
+	}
+
+	// avoid feign.codec.EncodeException - this feature works for users that override
+	// Encoder
+	protected static class NoCodecsFeignConfiguration {
+
+		@Bean
+		public Decoder decoder() {
+			return (response, type) -> response;
+		}
+
+		@Bean
+		public Encoder encoder() {
+			return (object, bodyType, request) -> request.body(object.toString().getBytes(), Charset.defaultCharset());
+		}
+
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractSlashEncodingIntegrationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractSlashEncodingIntegrationTests.java
@@ -23,32 +23,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 
 /**
  * Integration tests for {@link SpringMvcContract}
  *
- * @author Olga Maciaszek-Sharma
  * @author Ram Anaswara
  */
-@SpringBootTest(classes = AbstractSpringMvcContractIntegrationTests.Config.class,
-		webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-public class SpringMvcContractIntegrationTests extends AbstractSpringMvcContractIntegrationTests {
+@SpringBootTest(classes = SpringMvcContractSlashEncodingIntegrationTests.Config.class,
+		webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT, properties = { "feign.client.decodeSlash=false" })
+public class SpringMvcContractSlashEncodingIntegrationTests extends AbstractSpringMvcContractIntegrationTests {
 
 	@Autowired
 	private TestClient client;
 
 	@Test
-	public void shouldNotThrowInvalidMediaTypeExceptionWhenContentTypeTemplateUsed() {
-		assertThatCode(() -> client.sendMessage("test", "text/markdown")).doesNotThrowAnyException();
-	}
-
-	@Test
-	public void feignClientShouldPreserveSlash() {
+	public void feignClientShouldNotDecodeEncodedSlash() {
 		Response response = (Response) client.getMessage("https://www.google.com");
 
 		String urlQueryParam = getUrlQueryParam(response);
-		assertThat(urlQueryParam).isEqualTo("https%3A//www.google.com");
+		assertThat(urlQueryParam).isEqualTo("https%3A%2F%2Fwww.google.com");
 	}
 
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
@@ -114,11 +114,7 @@ public class SpringMvcContractTests {
 
 	@Before
 	public void setup() {
-		FormattingConversionServiceFactoryBean conversionServiceFactoryBean = new FormattingConversionServiceFactoryBean();
-		conversionServiceFactoryBean.afterPropertiesSet();
-		ConversionService conversionService = conversionServiceFactoryBean.getObject();
-
-		contract = new SpringMvcContract(Collections.emptyList(), conversionService);
+		contract = new SpringMvcContract(Collections.emptyList(), getConversionService());
 	}
 
 	@Test
@@ -130,6 +126,20 @@ public class SpringMvcContractTests {
 		assertThat(data.template().method()).isEqualTo("GET");
 		assertThat(data.template().headers().get("Accept").iterator().next())
 				.isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+
+		assertThat(data.template().decodeSlash()).isTrue();
+	}
+
+	@Test
+	public void testProcessAnnotationOnMethod_Simple_SlashEncoded() throws Exception {
+		contract = new SpringMvcContract(Collections.emptyList(), getConversionService(), false);
+
+		Method method = TestTemplate_Simple.class.getDeclaredMethod("getTest", String.class);
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/test/{id}");
+
+		assertThat(data.template().decodeSlash()).isFalse();
 	}
 
 	@Test
@@ -180,6 +190,20 @@ public class SpringMvcContractTests {
 		assertThat(data.template().method()).isEqualTo("GET");
 
 		assertThat(data.indexToName().get(0).iterator().next()).isEqualTo("classId");
+
+		assertThat(data.template().decodeSlash()).isTrue();
+	}
+
+	@Test
+	public void testProcessAnnotations_Class_AnnotationsGetAllTests_EncodeSlash() throws Exception {
+		contract = new SpringMvcContract(Collections.emptyList(), getConversionService(), false);
+
+		Method method = TestTemplate_Class_Annotations.class.getDeclaredMethod("getAllTests", String.class);
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/prepend/{classId}");
+
+		assertThat(data.template().decodeSlash()).isFalse();
 	}
 
 	@Test
@@ -195,6 +219,26 @@ public class SpringMvcContractTests {
 		assertThat(data.template().method()).isEqualTo(extendedData.template().method());
 
 		assertThat(data.indexToName().get(0).iterator().next()).isEqualTo(data.indexToName().get(0).iterator().next());
+
+		assertThat(data.template().decodeSlash()).isTrue();
+	}
+
+	@Test
+	public void testProcessAnnotations_ExtendedInterface_EncodeSlash() throws Exception {
+		contract = new SpringMvcContract(Collections.emptyList(), getConversionService(), false);
+
+		Method extendedMethod = TestTemplate_Extended.class.getMethod("getAllTests", String.class);
+		MethodMetadata extendedData = contract.parseAndValidateMetadata(extendedMethod.getDeclaringClass(),
+				extendedMethod);
+
+		Method method = TestTemplate_Class_Annotations.class.getDeclaredMethod("getAllTests", String.class);
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo(extendedData.template().url());
+		assertThat(data.template().method()).isEqualTo(extendedData.template().method());
+
+		assertThat(data.template().decodeSlash()).isFalse();
+
 	}
 
 	@Test
@@ -343,6 +387,21 @@ public class SpringMvcContractTests {
 		assertThat(data.template().method()).isEqualTo("GET");
 		assertThat(data.template().headers().get("Accept").iterator().next())
 				.isEqualTo(MediaType.APPLICATION_JSON_VALUE);
+
+		assertThat(data.template().decodeSlash()).isTrue();
+	}
+
+	@Test
+	public void testProcessAnnotations_Advanced3_DecodeSlashFlagNotModified() throws Exception {
+		contract = new SpringMvcContract(Collections.emptyList(), getConversionService(), false);
+
+		Method method = TestTemplate_Simple.class.getDeclaredMethod("getTest");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/");
+
+		assertThat(data.template().decodeSlash()).isTrue();
+
 	}
 
 	@Test
@@ -522,6 +581,12 @@ public class SpringMvcContractTests {
 
 		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
 		assertThat(data.formParams()).contains("file", "id");
+	}
+
+	private ConversionService getConversionService() {
+		FormattingConversionServiceFactoryBean conversionServiceFactoryBean = new FormattingConversionServiceFactoryBean();
+		conversionServiceFactoryBean.afterPropertiesSet();
+		return conversionServiceFactoryBean.getObject();
 	}
 
 	public interface TestTemplate_Simple {


### PR DESCRIPTION
Fixes #3 

Feign clients do not encode slash `/` characters by default. To change this behaviour, set the `decodeSlash` property to `false`.

feign.client.decodeSlash=false