### PR TITLE
Support to set loadBalancerKey from request header

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/ribbon/FeignLoadBalancer.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/ribbon/FeignLoadBalancer.java
@@ -33,6 +33,7 @@ import com.netflix.client.RetryHandler;
 import com.netflix.client.config.IClientConfig;
 import com.netflix.loadbalancer.ILoadBalancer;
 import com.netflix.loadbalancer.Server;
+import com.netflix.loadbalancer.reactive.LoadBalancerCommand;
 import feign.Client;
 import feign.Request;
 import feign.Response;
@@ -91,6 +92,11 @@ public class FeignLoadBalancer extends
 		}
 		Response response = request.client().execute(request.toRequest(), options);
 		return new RibbonResponse(request.getUri(), response);
+	}
+
+	@Override
+	protected void customizeLoadBalancerCommandBuilder(RibbonRequest request, IClientConfig config, LoadBalancerCommand.Builder<RibbonResponse> builder) {
+		builder.withServerLocator(request.request.headers().get("loadBalancerKey"));
 	}
 
 	@Override


### PR DESCRIPTION
When I write myself `MyRule` implements `IRule`, the key is always null, like below:

```java
public class MyRule extends AbstractLoadBalancerRule {

    @Override
    public Server choose(Object key) {
          // here the key is always null
    }
}
```

By watching the source code, I find there's no where to set this `loadBalancerKey`. So I push this PR to resolve this problem by overriding `FeignLoadBalancer#customizeLoadBalancerCommandBuilder` method.

```java
         // override FeignLoadBalancer#customizeLoadBalancerCommandBuilder
	@Override
	protected void customizeLoadBalancerCommandBuilder(RibbonRequest request, IClientConfig config, LoadBalancerCommand.Builder<RibbonResponse> builder) {
		builder.withServerLocator(request.request.headers().get("loadBalancerKey"));
	}
```

By this way, I can put my `loadBalancerKey` from `feign.RequestInterceptor` implementation like this:

```java
public class MyRequestInterceptor implements RequestInterceptor {
    @Override
    public void apply(RequestTemplate template) {
        template.header("loadBalancerKey", "gray");
    }
}
```

Then in `MyRule` I can get the key:

```java
public class MyRule extends AbstractLoadBalancerRule {

    @Override
    public Server choose(Object key) {
          // no the key equals to gray
    }
}
```

This is all.