### PR TITLE
Lazy openfeign bean registration

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
@@ -30,6 +30,9 @@ import org.springframework.beans.factory.annotation.AnnotatedBeanDefinition;
 import org.springframework.beans.factory.annotation.AnnotatedGenericBeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.config.BeanDefinitionHolder;
+import org.springframework.beans.factory.config.BeanExpressionContext;
+import org.springframework.beans.factory.config.BeanExpressionResolver;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.beans.factory.support.AbstractBeanDefinition;
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.beans.factory.support.BeanDefinitionReaderUtils;
@@ -194,19 +197,35 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 	private void registerFeignClient(BeanDefinitionRegistry registry, AnnotationMetadata annotationMetadata,
 			Map<String, Object> attributes) {
 		String className = annotationMetadata.getClassName();
-		BeanDefinitionBuilder definition = BeanDefinitionBuilder.genericBeanDefinition(FeignClientFactoryBean.class);
-		validate(attributes);
-		definition.addPropertyValue("url", getUrl(attributes));
-		definition.addPropertyValue("path", getPath(attributes));
+		Class clazz = ClassUtils.resolveClassName(className, null);
+		ConfigurableBeanFactory beanFactory = registry instanceof ConfigurableBeanFactory
+				? (ConfigurableBeanFactory) registry : null;
+		String contextId = getContextId(beanFactory, attributes);
 		String name = getName(attributes);
-		definition.addPropertyValue("name", name);
-		String contextId = getContextId(attributes);
-		definition.addPropertyValue("contextId", contextId);
-		definition.addPropertyValue("type", className);
-		definition.addPropertyValue("decode404", attributes.get("decode404"));
-		definition.addPropertyValue("fallback", attributes.get("fallback"));
-		definition.addPropertyValue("fallbackFactory", attributes.get("fallbackFactory"));
+		BeanDefinitionBuilder definition = BeanDefinitionBuilder.genericBeanDefinition(clazz, () -> {
+			FeignClientFactoryBean factoryBean = new FeignClientFactoryBean();
+			factoryBean.setBeanFactory(beanFactory);
+			factoryBean.setUrl(getUrl(beanFactory, attributes));
+			factoryBean.setPath(getPath(beanFactory, attributes));
+			factoryBean.setName(name);
+			factoryBean.setContextId(contextId);
+			factoryBean.setType(clazz);
+			factoryBean.setDecode404(Boolean.parseBoolean(String.valueOf(attributes.get("decode404"))));
+			Object fallback = attributes.get("fallback");
+			if (fallback != null) {
+				factoryBean.setFallback(fallback instanceof Class ? (Class<?>) fallback
+						: ClassUtils.resolveClassName(fallback.toString(), null));
+			}
+			Object fallbackFactory = attributes.get("fallbackFactory");
+			if (fallbackFactory != null) {
+				factoryBean.setFallbackFactory(fallbackFactory instanceof Class ? (Class<?>) fallbackFactory
+						: ClassUtils.resolveClassName(fallbackFactory.toString(), null));
+			}
+			return factoryBean.getObject();
+		});
 		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE);
+		definition.setLazyInit(true);
+		validate(attributes);
 
 		String alias = contextId + "FeignClient";
 		AbstractBeanDefinition beanDefinition = definition.getBeanDefinition();
@@ -235,6 +254,10 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 	}
 
 	/* for testing */ String getName(Map<String, Object> attributes) {
+		return getName(null, attributes);
+	}
+
+	String getName(ConfigurableBeanFactory beanFactory, Map<String, Object> attributes) {
 		String name = (String) attributes.get("serviceId");
 		if (!StringUtils.hasText(name)) {
 			name = (String) attributes.get("name");
@@ -242,34 +265,42 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 		if (!StringUtils.hasText(name)) {
 			name = (String) attributes.get("value");
 		}
-		name = resolve(name);
+		name = resolve(beanFactory, name);
 		return getName(name);
 	}
 
-	private String getContextId(Map<String, Object> attributes) {
+	private String getContextId(ConfigurableBeanFactory beanFactory, Map<String, Object> attributes) {
 		String contextId = (String) attributes.get("contextId");
 		if (!StringUtils.hasText(contextId)) {
 			return getName(attributes);
 		}
 
-		contextId = resolve(contextId);
+		contextId = resolve(beanFactory, contextId);
 		return getName(contextId);
 	}
 
-	private String resolve(String value) {
+	private String resolve(ConfigurableBeanFactory beanFactory, String value) {
 		if (StringUtils.hasText(value)) {
-			return this.environment.resolvePlaceholders(value);
+			if (beanFactory == null) {
+				return this.environment.resolvePlaceholders(value);
+			}
+			BeanExpressionResolver resolver = beanFactory.getBeanExpressionResolver();
+			String resolved = beanFactory.resolveEmbeddedValue(value);
+			if (resolver == null) {
+				return resolved;
+			}
+			return String.valueOf(resolver.evaluate(resolved, new BeanExpressionContext(beanFactory, null)));
 		}
 		return value;
 	}
 
-	private String getUrl(Map<String, Object> attributes) {
-		String url = resolve((String) attributes.get("url"));
+	private String getUrl(ConfigurableBeanFactory beanFactory, Map<String, Object> attributes) {
+		String url = resolve(beanFactory, (String) attributes.get("url"));
 		return getUrl(url);
 	}
 
-	private String getPath(Map<String, Object> attributes) {
-		String path = resolve((String) attributes.get("path"));
+	private String getPath(ConfigurableBeanFactory beanFactory, Map<String, Object> attributes) {
+		String path = resolve(beanFactory, (String) attributes.get("path"));
 		return getPath(path);
 	}
 

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
@@ -202,14 +202,14 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 				? (ConfigurableBeanFactory) registry : null;
 		String contextId = getContextId(beanFactory, attributes);
 		String name = getName(attributes);
+		FeignClientFactoryBean factoryBean = new FeignClientFactoryBean();
+		factoryBean.setBeanFactory(beanFactory);
+		factoryBean.setName(name);
+		factoryBean.setContextId(contextId);
+		factoryBean.setType(clazz);
 		BeanDefinitionBuilder definition = BeanDefinitionBuilder.genericBeanDefinition(clazz, () -> {
-			FeignClientFactoryBean factoryBean = new FeignClientFactoryBean();
-			factoryBean.setBeanFactory(beanFactory);
 			factoryBean.setUrl(getUrl(beanFactory, attributes));
 			factoryBean.setPath(getPath(beanFactory, attributes));
-			factoryBean.setName(name);
-			factoryBean.setContextId(contextId);
-			factoryBean.setType(clazz);
 			factoryBean.setDecode404(Boolean.parseBoolean(String.valueOf(attributes.get("decode404"))));
 			Object fallback = attributes.get("fallback");
 			if (fallback != null) {
@@ -230,6 +230,7 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 		String alias = contextId + "FeignClient";
 		AbstractBeanDefinition beanDefinition = definition.getBeanDefinition();
 		beanDefinition.setAttribute(FactoryBean.OBJECT_TYPE_ATTRIBUTE, className);
+		beanDefinition.setAttribute("feignClientsRegistrarFactoryBean", factoryBean);
 
 		// has a default, won't be null
 		boolean primary = (Boolean) attributes.get("primary");

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientUsingConfigurerTest.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientUsingConfigurerTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import feign.Feign;
 import feign.Logger;
 import feign.RequestInterceptor;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -47,9 +48,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 		"feign.client.config.default.loggerLevel=full",
 		"feign.client.config.default.requestInterceptors[0]=org.springframework.cloud.openfeign.FeignClientUsingPropertiesTests.FooRequestInterceptor",
 		"feign.client.config.default.requestInterceptors[1]=org.springframework.cloud.openfeign.FeignClientUsingPropertiesTests.BarRequestInterceptor" })
+@Ignore("I don't know how to test this since the factory bean is no longer created")
 public class FeignClientUsingConfigurerTest {
 
-	private static final String BEAN_NAME_PREFIX = "&org.springframework.cloud.openfeign.FeignClientUsingConfigurerTest$";
+	private static final String BEAN_NAME_PREFIX = "org.springframework.cloud.openfeign.FeignClientUsingConfigurerTest$";
 
 	@Autowired
 	private ApplicationContext applicationContext;

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientUsingConfigurerTest.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientUsingConfigurerTest.java
@@ -22,15 +22,14 @@ import java.util.List;
 import feign.Feign;
 import feign.Logger;
 import feign.RequestInterceptor;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.cloud.openfeign.clientconfig.FeignClientConfigurer;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
@@ -48,21 +47,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 		"feign.client.config.default.loggerLevel=full",
 		"feign.client.config.default.requestInterceptors[0]=org.springframework.cloud.openfeign.FeignClientUsingPropertiesTests.FooRequestInterceptor",
 		"feign.client.config.default.requestInterceptors[1]=org.springframework.cloud.openfeign.FeignClientUsingPropertiesTests.BarRequestInterceptor" })
-@Ignore("I don't know how to test this since the factory bean is no longer created")
 public class FeignClientUsingConfigurerTest {
 
 	private static final String BEAN_NAME_PREFIX = "org.springframework.cloud.openfeign.FeignClientUsingConfigurerTest$";
 
 	@Autowired
-	private ApplicationContext applicationContext;
+	private ConfigurableListableBeanFactory beanFactory;
 
 	@Autowired
 	private FeignContext context;
 
 	@Test
 	public void testFeignClient() {
-		FeignClientFactoryBean factoryBean = (FeignClientFactoryBean) applicationContext
-				.getBean(BEAN_NAME_PREFIX + "TestFeignClient");
+		FeignClientFactoryBean factoryBean = (FeignClientFactoryBean) beanFactory
+				.getBeanDefinition(BEAN_NAME_PREFIX + "TestFeignClient")
+				.getAttribute("feignClientsRegistrarFactoryBean");
 		Feign.Builder builder = factoryBean.feign(context);
 
 		List<RequestInterceptor> interceptors = (List) getBuilderValue(builder, "requestInterceptors");
@@ -79,8 +78,9 @@ public class FeignClientUsingConfigurerTest {
 
 	@Test
 	public void testNoInheritFeignClient() {
-		FeignClientFactoryBean factoryBean = (FeignClientFactoryBean) applicationContext
-				.getBean(BEAN_NAME_PREFIX + "NoInheritFeignClient");
+		FeignClientFactoryBean factoryBean = (FeignClientFactoryBean) beanFactory
+				.getBeanDefinition(BEAN_NAME_PREFIX + "NoInheritFeignClient")
+				.getAttribute("feignClientsRegistrarFactoryBean");
 		Feign.Builder builder = factoryBean.feign(context);
 
 		List<RequestInterceptor> interceptors = (List) getBuilderValue(builder, "requestInterceptors");
@@ -91,8 +91,9 @@ public class FeignClientUsingConfigurerTest {
 
 	@Test
 	public void testNoInheritFeignClient_ignoreProperties() {
-		FeignClientFactoryBean factoryBean = (FeignClientFactoryBean) applicationContext
-				.getBean(BEAN_NAME_PREFIX + "NoInheritFeignClient");
+		FeignClientFactoryBean factoryBean = (FeignClientFactoryBean) beanFactory
+				.getBeanDefinition(BEAN_NAME_PREFIX + "NoInheritFeignClient")
+				.getAttribute("feignClientsRegistrarFactoryBean");
 		Feign.Builder builder = factoryBean.feign(context);
 
 		assertThat(getBuilderValue(builder, "logLevel")).as("log level not set").isEqualTo(Logger.Level.HEADERS);


### PR DESCRIPTION
without this change we're eagerly resolving placeholder properties in passed URLs / names. Since this happens at bean definition level it's extremely early e.g. Spring Cloud Contract has not yet registered any placeholders that Feign could try to consume.
with this change we're changing the bean to become lazy initialized and we resolve the placeholder values at runtime - as late as possible.

problems:
- one of the tests uses the factory bean - there's no more factory bean since the instance supplier for the bean registration acts as one

related issue https://github.com/spring-cloud/spring-cloud-contract/issues/1303