### PR TITLE
Encode Pageable.Sort with percent encoded comma. Fixes gh-440.

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringEncoder.java
@@ -120,7 +120,7 @@ public class PageableSpringEncoder implements Encoder {
 			}
 		}
 		for (Sort.Order order : sort) {
-			sortQueries.add(order.getProperty() + "," + order.getDirection());
+			sortQueries.add(order.getProperty() + "%2C" + order.getDirection());
 		}
 		if (!sortQueries.isEmpty()) {
 			template.query(sortParameter, sortQueries);

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignPageableEncodingTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignPageableEncodingTests.java
@@ -108,13 +108,18 @@ public class FeignPageableEncodingTests {
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(response.getBody()).isNotNull();
 		assertThat(pageable.getPageSize()).isEqualTo(response.getBody().getSize());
-		assertThat(response.getBody().getPageable().getSort()).hasSize(1);
-		Optional<Sort.Order> optionalOrder = response.getBody().getPageable().getSort().get().findFirst();
-		if (optionalOrder.isPresent()) {
-			Sort.Order order = optionalOrder.get();
-			assertThat(order.getDirection()).isEqualTo(Sort.Direction.DESC);
-			assertThat(order.getProperty()).isEqualTo("sortProperty");
-		}
+
+		Sort sort = response.getBody().getPageable().getSort();
+		assertThat(sort).hasSize(1);
+		assertThat(sort.get()).hasSize(1);
+
+		Optional<Sort.Order> optionalOrder = sort.get().findFirst();
+		assertThat(optionalOrder.isPresent()).isTrue();
+
+		Sort.Order order = optionalOrder.get();
+		assertThat(order.getDirection()).isEqualTo(Sort.Direction.DESC);
+		assertThat(order.getProperty()).isEqualTo("sortProperty");
+
 	}
 
 	@Test
@@ -131,17 +136,21 @@ public class FeignPageableEncodingTests {
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(response.getBody()).isNotNull();
 		assertThat(pageable.getPageSize()).isEqualTo(response.getBody().getSize());
-		assertThat(response.getBody().getPageable().getSort()).hasSize(2);
-		List<Sort.Order> orderList = response.getBody().getPageable().getSort().toList();
-		if (!orderList.isEmpty()) {
-			Sort.Order firstOrder = orderList.get(0);
-			assertThat(firstOrder.getDirection()).isEqualTo(Sort.Direction.DESC);
-			assertThat(firstOrder.getProperty()).isEqualTo("sortProperty1");
 
-			Sort.Order secondOrder = orderList.get(1);
-			assertThat(secondOrder.getDirection()).isEqualTo(Sort.Direction.ASC);
-			assertThat(secondOrder.getProperty()).isEqualTo("sortProperty2");
-		}
+		Sort sort = response.getBody().getPageable().getSort();
+		assertThat(sort).hasSize(2);
+
+		List<Sort.Order> orderList = sort.toList();
+		assertThat(orderList).hasSize(2);
+
+		Sort.Order firstOrder = orderList.get(0);
+		assertThat(firstOrder.getDirection()).isEqualTo(Sort.Direction.DESC);
+		assertThat(firstOrder.getProperty()).isEqualTo("sortProperty1");
+
+		Sort.Order secondOrder = orderList.get(1);
+		assertThat(secondOrder.getDirection()).isEqualTo(Sort.Direction.ASC);
+		assertThat(secondOrder.getProperty()).isEqualTo("sortProperty2");
+
 	}
 
 	@EnableFeignClients(clients = InvoiceClient.class)


### PR DESCRIPTION
I've modified https://github.com/spring-cloud/spring-cloud-openfeign/blob/faff6aef8acdf2367c1b5596a384cbe86e1200c5/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringEncoder.java as suggested in #440 along with corresponding tests.

https://github.com/spring-cloud/spring-cloud-openfeign/blob/faff6aef8acdf2367c1b5596a384cbe86e1200c5/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringEncoder.java#L119

If you run tests which I add without the patch of `PageSpringEncoder.java` and you'll be able to see the test fails.