### PR TITLE
Add configuration metadata for feign.autoconfiguration.jackson.enabled

### DIFF
--- a/spring-cloud-openfeign-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-openfeign-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -9,6 +9,12 @@
 			"defaultValue": "false"
 		},
 		{
+			"name": "feign.autoconfiguration.jackson.enabled",
+			"type": "java.lang.Boolean",
+			"description": "If true, PageJacksonModule and SortJacksonModule bean will be provided for Jackson page decoding.",
+			"defaultValue": "false"
+		},
+		{
 			"name": "feign.circuitbreaker.enabled",
 			"type": "java.lang.Boolean",
 			"description": "If true, an OpenFeign client will be wrapped with a Spring Cloud CircuitBreaker circuit breaker.",


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/6624567/106560210-fe753e00-6569-11eb-8237-6fc8a9b19364.png)

#430 haven't added configuration metadata for `feign.autoconfiguration.jackson.enabled`, so I added it.

I've seen #470, so `defaultValue` can be changed by next major release.