### PR TITLE
Fixes #482 No bean found of type Targeter.

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
@@ -40,6 +40,7 @@ import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.impl.client.CloseableHttpClient;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -114,8 +115,7 @@ public class FeignAutoConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnMissingClass({ "feign.hystrix.HystrixFeign",
-			"org.springframework.cloud.client.circuitbreaker.CircuitBreaker" })
+	@AutoConfigureAfter(HystrixFeignTargeterConfiguration.class)
 	protected static class DefaultFeignTargeterConfiguration {
 
 		@Bean
@@ -128,6 +128,9 @@ public class FeignAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(name = "feign.hystrix.HystrixFeign")
+	@ConditionalOnProperty(value = "feign.hystrix.enabled", havingValue = "true",
+			matchIfMissing = true)
+	@AutoConfigureAfter(CircuitBreakerPresentFeignTargeterConfiguration.class)
 	protected static class HystrixFeignTargeterConfiguration {
 
 		@Bean
@@ -140,14 +143,8 @@ public class FeignAutoConfiguration {
 
 	@Configuration(proxyBeanMethods = false)
 	@ConditionalOnClass(CircuitBreaker.class)
-	@ConditionalOnProperty("feign.circuitbreaker.enabled")
+	@ConditionalOnProperty(value = "feign.circuitbreaker.enabled", havingValue = "true")
 	protected static class CircuitBreakerPresentFeignTargeterConfiguration {
-
-		@Bean
-		@ConditionalOnMissingBean(CircuitBreakerFactory.class)
-		public Targeter defaultFeignTargeter() {
-			return new DefaultTargeter();
-		}
 
 		@Bean
 		@ConditionalOnMissingBean

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
@@ -69,6 +69,7 @@ import org.springframework.data.domain.Sort;
  * @author Julien Roy
  * @author Grzegorz Poznachowski
  * @author Nikita Konev
+ * @author Tim Peeters
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(Feign.class)

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/HystrixDisabledConditions.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/HystrixDisabledConditions.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign;
+
+import org.springframework.boot.autoconfigure.condition.AnyNestedCondition;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+
+/**
+ * @author Tim Peeters
+ */
+class HystrixDisabledConditions extends AnyNestedCondition {
+
+	HystrixDisabledConditions() {
+		super(ConfigurationPhase.PARSE_CONFIGURATION);
+	}
+
+	@ConditionalOnMissingClass("feign.hystrix.HystrixFeign")
+	static class HystrixFeignClassMissing {
+
+	}
+
+	@ConditionalOnProperty(value = "feign.hystrix.enabled", havingValue = "false")
+	static class HystrixFeignDisabled {
+
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.cloud.netflix.hystrix.HystrixCircuitBreakerFactory;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FeignAutoConfigurationTests {
+
+	@Test
+	void shouldInstantiateFeignHystrixTargeter() {
+		ConfigurableApplicationContext context = contextBuilder()
+				.sources(FeignAutoConfiguration.class).run();
+		assertThatOneBeanPresent(context, HystrixTargeter.class);
+	}
+
+	@Test
+	void shouldInstantiateDefaultFeignTargeterWhenHystrixDisabled() {
+		ConfigurableApplicationContext context = contextBuilder()
+				.properties("feign.hystrix.enabled=false")
+				.sources(FeignAutoConfiguration.class).run();
+		assertThatOneBeanPresent(context, DefaultTargeter.class);
+	}
+
+	@Test
+	void shouldInstantiateFeignCircuitBreakerTargeterWhenCircuitBreakerEnabled() {
+		ConfigurableApplicationContext context = contextBuilder()
+				.properties("feign.circuitbreaker.enabled=true")
+				.sources(CircuitBreakerFactoryConfig.class, FeignAutoConfiguration.class)
+				.run();
+		assertThatOneBeanPresent(context, FeignCircuitBreakerTargeter.class);
+	}
+
+	private SpringApplicationBuilder contextBuilder() {
+		return new SpringApplicationBuilder().web(WebApplicationType.NONE);
+	}
+
+	private void assertThatOneBeanPresent(ConfigurableApplicationContext context,
+			Class<?> beanClass) {
+		Map<String, ?> beans = context.getBeansOfType(beanClass);
+		assertThat(beans).hasSize(1);
+	}
+
+	@Configuration
+	static class CircuitBreakerFactoryConfig {
+
+		@Bean
+		HystrixCircuitBreakerFactory circuitBreakerFactory() {
+			return new HystrixCircuitBreakerFactory();
+		}
+
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
@@ -29,6 +29,9 @@ import org.springframework.context.annotation.Configuration;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+/**
+ * @author Tim Peeters
+ */
 class FeignAutoConfigurationTests {
 
 	@Test


### PR DESCRIPTION
Changes:

- Removed `@ConditionalOnMissingClass(HystrixFeign, CircuitBreaker)` on `DefaultFeignTargeterConfiguration`. Both classes are present by default and this causes the DefaultTargeter not to be considered even if Hystrix and CircuitBreaker are disabled.
- Position `DefaultTargeter` behind `HystrixTargeter` using `@AutoConfigureAfter`
- Position `HystrixTargeter` behind `CircuitBreakerTarger` using `@AutoConfigureAfter`
- Make it possible to disable `HystrixTargeter` by setting `feign.hystrix.enabled` to `false`. Keep default behaviour from previous release where  `HystrixTargeter` was the default (`matchIfMissing`).
- Only enable `CircuitBreakerTargeter` if `feign.circuitbreaker.enabled` is true