### PR TITLE
mentioning Feign instead of Sleuth

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -661,4 +661,4 @@ feign.autoconfiguration.jackson.enabled=true
 
 == Configuration properties
 
-To see the list of all Feign related configuration properties please check link:appendix.html[the Appendix page].
+To see the list of all Spring Cloud OpenFeign related configuration properties please check link:appendix.html[the Appendix page].

--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -661,4 +661,4 @@ feign.autoconfiguration.jackson.enabled=true
 
 == Configuration properties
 
-To see the list of all Sleuth related configuration properties please check link:appendix.html[the Appendix page].
+To see the list of all Feign related configuration properties please check link:appendix.html[the Appendix page].


### PR DESCRIPTION
In The last line in Feign's reference docs Sleuth mentioned instead of Feign. I have corrected this very very small mistake.