### PR TITLE
Support Pageable, Sort annotated as SpringQueryMap to use with RequestBody

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -23,6 +23,7 @@ import com.netflix.hystrix.HystrixCommand;
 import feign.Contract;
 import feign.Feign;
 import feign.Logger;
+import feign.QueryMapEncoder;
 import feign.Retryer;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
@@ -47,6 +48,7 @@ import org.springframework.cloud.openfeign.clientconfig.FeignClientConfigurer;
 import org.springframework.cloud.openfeign.support.AbstractFormWriter;
 import org.springframework.cloud.openfeign.support.FeignEncoderProperties;
 import org.springframework.cloud.openfeign.support.PageableSpringEncoder;
+import org.springframework.cloud.openfeign.support.PageableSpringQueryMapEncoder;
 import org.springframework.cloud.openfeign.support.ResponseEntityDecoder;
 import org.springframework.cloud.openfeign.support.SpringDecoder;
 import org.springframework.cloud.openfeign.support.SpringEncoder;
@@ -65,6 +67,7 @@ import static feign.form.ContentType.MULTIPART;
  * @author Venil Noronha
  * @author Darren Foong
  * @author Olga Maciaszek-Sharma
+ * @author Hyeonmin Park
  */
 @Configuration(proxyBeanMethods = false)
 public class FeignClientsConfiguration {
@@ -121,6 +124,13 @@ public class FeignClientsConfiguration {
 					springDataWebProperties.getSort().getSortParameter());
 		}
 		return encoder;
+	}
+
+	@Bean
+	@ConditionalOnClass(name = "org.springframework.data.domain.Pageable")
+	@ConditionalOnMissingBean
+	public QueryMapEncoder feignQueryMapEncoderPageable() {
+		return new PageableSpringQueryMapEncoder();
 	}
 
 	@Bean

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2013-2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.support;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import feign.querymap.BeanQueryMapEncoder;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+
+/**
+ * Provides support for encoding Pageable annotated as SpringQueryMap.
+ *
+ * @author Hyeonmin Park
+ */
+public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
+
+	@Override
+	public Map<String, Object> encode(Object object) {
+		if (supports(object)) {
+			Map<String, Object> queryMap = new HashMap<>();
+
+			if (object instanceof Pageable) {
+				Pageable pageable = (Pageable) object;
+
+				if (pageable.isPaged()) {
+					queryMap.put("page", pageable.getPageNumber());
+					queryMap.put("size", pageable.getPageSize());
+				}
+
+				if (pageable.getSort() != null) {
+					applySort(queryMap, pageable.getSort());
+				}
+			}
+			else if (object instanceof Sort) {
+				Sort sort = (Sort) object;
+				applySort(new HashMap<>(), sort);
+			}
+			return queryMap;
+		}
+		else {
+			return super.encode(object);
+		}
+	}
+
+	private void applySort(Map<String, Object> queryMap, Sort sort) {
+		List<String> sortQueries = new ArrayList<>();
+		for (Sort.Order order : sort) {
+			sortQueries.add(order.getProperty() + "%2C" + order.getDirection());
+		}
+		if (!sortQueries.isEmpty()) {
+			queryMap.put("sort", sortQueries);
+		}
+	}
+
+	protected boolean supports(Object object) {
+		return object instanceof Pageable || object instanceof Sort;
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
@@ -54,7 +54,7 @@ public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
 			}
 			else if (object instanceof Sort) {
 				Sort sort = (Sort) object;
-				applySort(new HashMap<>(), sort);
+				applySort(queryMap, sort);
 			}
 			return queryMap;
 		}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
@@ -27,9 +27,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 
 /**
- * Provides support for encoding Pageable annotated as SpringQueryMap.
+ * Provides support for encoding Pageable annotated as
+ * {@link org.springframework.cloud.openfeign.SpringQueryMap}.
  *
  * @author Hyeonmin Park
+ * @since 2.2.8
  */
 public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignPageableEncodingTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignPageableEncodingTests.java
@@ -62,9 +62,7 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 		value = { "feign.compression.request.enabled=true",
 				"feign.autoconfiguration.jackson.enabled=true",
 				"hystrix.command.default.execution.isolation.strategy=SEMAPHORE",
-				"ribbon.OkToRetryOnAllOperations=false",
-				"feign.client.config.default.loggerLevel=full",
-				"logging.level.org.springframework.cloud.openfeign=DEBUG" })
+				"ribbon.OkToRetryOnAllOperations=false" })
 @RunWith(SpringJUnit4ClassRunner.class)
 public class FeignPageableEncodingTests {
 
@@ -159,8 +157,8 @@ public class FeignPageableEncodingTests {
 		Pageable pageable = PageRequest.of(0, 10);
 
 		// when
-		final ResponseEntity<Page<Invoice>> response =
-				this.invoiceClient.getInvoicesPagedWithBody(pageable, "InvoiceTitleFromBody");
+		final ResponseEntity<Page<Invoice>> response = this.invoiceClient
+				.getInvoicesPagedWithBody(pageable, "InvoiceTitleFromBody");
 
 		// then
 		assertThat(response).isNotNull();
@@ -178,12 +176,12 @@ public class FeignPageableEncodingTests {
 	@Test
 	public void testPageableWithBody() {
 		// given
-		Pageable pageable = PageRequest.of(0, 10,
-				Sort.by(Sort.Order.desc("sortProperty1"), Sort.Order.asc("sortProperty2")));
+		Pageable pageable = PageRequest.of(0, 10, Sort
+				.by(Sort.Order.desc("sortProperty1"), Sort.Order.asc("sortProperty2")));
 
 		// when
-		final ResponseEntity<Page<Invoice>> response =
-				this.invoiceClient.getInvoicesPagedWithBody(pageable, "InvoiceTitleFromBody");
+		final ResponseEntity<Page<Invoice>> response = this.invoiceClient
+				.getInvoicesPagedWithBody(pageable, "InvoiceTitleFromBody");
 
 		// then
 		assertThat(response).isNotNull();
@@ -218,8 +216,8 @@ public class FeignPageableEncodingTests {
 		Pageable unpaged = Pageable.unpaged();
 
 		// when
-		final ResponseEntity<Page<Invoice>> response =
-				this.invoiceClient.getInvoicesPagedWithBody(unpaged, "InvoiceTitleFromBody");
+		final ResponseEntity<Page<Invoice>> response = this.invoiceClient
+				.getInvoicesPagedWithBody(unpaged, "InvoiceTitleFromBody");
 
 		// then
 		assertThat(response).isNotNull();
@@ -236,22 +234,28 @@ public class FeignPageableEncodingTests {
 	@Test
 	public void testSortWithBody() {
 		// given
-		Sort sort = Sort.by(Sort.Order.desc("sortProperty"));
+		Sort sort = Sort.by(Sort.Order.desc("amount"));
 
 		// when
-		final ResponseEntity<List<Invoice>> response =
-				this.invoiceClient.getInvoicesSortedWithBody(sort, "InvoiceTitleFromBody");
+		final ResponseEntity<Page<Invoice>> response = this.invoiceClient
+				.getInvoicesSortedWithBody(sort, "InvoiceTitleFromBody");
 
 		// then
 		assertThat(response).isNotNull();
 		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
 		assertThat(response.getBody()).isNotNull();
+		assertThat(sort).isEqualTo(response.getBody().getSort());
 
-		List<Invoice> invoiceList = response.getBody();
+		List<Invoice> invoiceList = response.getBody().getContent();
 		assertThat(invoiceList).hasSizeGreaterThanOrEqualTo(1);
 
 		Invoice firstInvoice = invoiceList.get(0);
 		assertThat(firstInvoice.getTitle()).startsWith("InvoiceTitleFromBody");
+
+		for (int ind = 0; ind < invoiceList.size() - 1; ind++) {
+			assertThat(invoiceList.get(ind).getAmount())
+					.isGreaterThanOrEqualTo(invoiceList.get(ind + 1).getAmount());
+		}
 	}
 
 	@EnableFeignClients(clients = InvoiceClient.class)

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignPageableEncodingTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignPageableEncodingTests.java
@@ -152,6 +152,26 @@ public class FeignPageableEncodingTests {
 	}
 
 	@Test
+	public void testPageableWithoutSort() {
+		// given
+		Pageable pageable = PageRequest.of(0, 10);
+
+		// when
+		final ResponseEntity<Page<Invoice>> response = this.invoiceClient
+				.getInvoicesPaged(pageable);
+
+		// then
+		assertThat(response).isNotNull();
+		assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+		assertThat(response.getBody()).isNotNull();
+		assertThat(pageable.getPageSize()).isEqualTo(response.getBody().getSize());
+		assertThat(response.getBody().getPageable().getSort().isSorted()).isFalse();
+
+		List<Invoice> invoiceList = response.getBody().getContent();
+		assertThat(invoiceList).hasSizeGreaterThanOrEqualTo(1);
+	}
+
+	@Test
 	public void testPageableWithoutSortWithBody() {
 		// given
 		Pageable pageable = PageRequest.of(0, 10);

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/app/client/InvoiceClient.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/app/client/InvoiceClient.java
@@ -43,14 +43,18 @@ public interface InvoiceClient {
 			org.springframework.data.domain.Pageable pageable);
 
 	@RequestMapping(value = "invoicesPagedWithBody", method = RequestMethod.POST,
-			consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+			consumes = MediaType.APPLICATION_JSON_VALUE,
+			produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<Page<Invoice>> getInvoicesPagedWithBody(
-			@SpringQueryMap org.springframework.data.domain.Pageable pageable, @RequestBody String titlePrefix);
+			@SpringQueryMap org.springframework.data.domain.Pageable pageable,
+			@RequestBody String titlePrefix);
 
 	@RequestMapping(value = "invoicesSortedWithBody", method = RequestMethod.POST,
-			consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
-	ResponseEntity<List<Invoice>> getInvoicesSortedWithBody(
-			@SpringQueryMap org.springframework.data.domain.Sort sort, @RequestBody String titlePrefix);
+			consumes = MediaType.APPLICATION_JSON_VALUE,
+			produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<Page<Invoice>> getInvoicesSortedWithBody(
+			@SpringQueryMap org.springframework.data.domain.Sort sort,
+			@RequestBody String titlePrefix);
 
 	@RequestMapping(value = "invoices", method = RequestMethod.GET,
 			produces = MediaType.APPLICATION_JSON_VALUE)

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/app/client/InvoiceClient.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/app/client/InvoiceClient.java
@@ -19,10 +19,12 @@ package org.springframework.cloud.openfeign.encoding.app.client;
 import java.util.List;
 
 import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.cloud.openfeign.SpringQueryMap;
 import org.springframework.cloud.openfeign.encoding.app.domain.Invoice;
 import org.springframework.data.domain.Page;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 
@@ -30,6 +32,7 @@ import org.springframework.web.bind.annotation.RequestMethod;
  * Simple Feign client for retrieving the invoice list.
  *
  * @author Jakub Narloch
+ * @author Hyeonmin Park
  */
 @FeignClient("local")
 public interface InvoiceClient {
@@ -38,6 +41,16 @@ public interface InvoiceClient {
 			produces = MediaType.APPLICATION_JSON_VALUE)
 	ResponseEntity<Page<Invoice>> getInvoicesPaged(
 			org.springframework.data.domain.Pageable pageable);
+
+	@RequestMapping(value = "invoicesPagedWithBody", method = RequestMethod.POST,
+			consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<Page<Invoice>> getInvoicesPagedWithBody(
+			@SpringQueryMap org.springframework.data.domain.Pageable pageable, @RequestBody String titlePrefix);
+
+	@RequestMapping(value = "invoicesSortedWithBody", method = RequestMethod.POST,
+			consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	ResponseEntity<List<Invoice>> getInvoicesSortedWithBody(
+			@SpringQueryMap org.springframework.data.domain.Sort sort, @RequestBody String titlePrefix);
 
 	@RequestMapping(value = "invoices", method = RequestMethod.GET,
 			produces = MediaType.APPLICATION_JSON_VALUE)

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/app/resource/InvoiceResource.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/app/resource/InvoiceResource.java
@@ -35,6 +35,7 @@ import org.springframework.web.bind.annotation.RestController;
  * An sample REST controller, that potentially returns large response - used for testing.
  *
  * @author Jakub Narloch
+ * @author Hyeonmin Park
  */
 @RestController
 public class InvoiceResource {
@@ -63,11 +64,30 @@ public class InvoiceResource {
 		return ResponseEntity.ok(page);
 	}
 
+	@RequestMapping(value = "invoicesPagedWithBody", method = RequestMethod.POST,
+			consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<Page<Invoice>> getInvoicesPagedWithBody(org.springframework.data.domain.Pageable pageable,
+			@RequestBody String titlePrefix) {
+		Page<Invoice> page = new PageImpl<>(createInvoiceList(titlePrefix, pageable.getPageSize()), pageable, 100);
+		return ResponseEntity.ok(page);
+	}
+
+	@RequestMapping(value = "invoicesSortedWithBody", method = RequestMethod.POST,
+			consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<List<Invoice>> getInvoicesSortedWithBody(org.springframework.data.domain.Sort sort,
+			@RequestBody String titlePrefix) {
+		return ResponseEntity.ok(createInvoiceList(titlePrefix, 100));
+	}
+
 	private List<Invoice> createInvoiceList(int count) {
+		return createInvoiceList("Invoice", count);
+	}
+
+	private List<Invoice> createInvoiceList(String titlePrefix, int count) {
 		final List<Invoice> invoices = new ArrayList<>();
 		for (int ind = 0; ind < count; ind++) {
 			final Invoice invoice = new Invoice();
-			invoice.setTitle("Invoice " + (ind + 1));
+			invoice.setTitle(titlePrefix + " " + (ind + 1));
 			invoice.setAmount(new BigDecimal(
 					String.format(Locale.US, "%.2f", Math.random() * 1000)));
 			invoices.add(invoice);

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/app/resource/InvoiceResource.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/app/resource/InvoiceResource.java
@@ -46,7 +46,7 @@ public class InvoiceResource {
 			produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<Invoice>> getInvoices() {
 
-		return ResponseEntity.ok(createInvoiceList(100));
+		return ResponseEntity.ok(createInvoiceList(null, 100, null));
 	}
 
 	@RequestMapping(value = "invoices", method = RequestMethod.POST,
@@ -61,7 +61,8 @@ public class InvoiceResource {
 			produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<Page<Invoice>> getInvoicesPaged(
 			org.springframework.data.domain.Pageable pageable) {
-		Page<Invoice> page = new PageImpl<>(createInvoiceList(pageable.getPageSize()),
+		Page<Invoice> page = new PageImpl<>(
+				createInvoiceList(null, pageable.getPageSize(), pageable.getSort()),
 				pageable, 100);
 		return ResponseEntity.ok(page);
 	}
@@ -87,12 +88,11 @@ public class InvoiceResource {
 		return ResponseEntity.ok(page);
 	}
 
-	private List<Invoice> createInvoiceList(int count) {
-		return createInvoiceList("Invoice", count, null);
-	}
-
 	private List<Invoice> createInvoiceList(String titlePrefix, int count,
 			org.springframework.data.domain.Sort sort) {
+		if (titlePrefix == null) {
+			titlePrefix = "Invoice";
+		}
 		final List<Invoice> invoices = new ArrayList<>();
 		for (int ind = 0; ind < count; ind++) {
 			final Invoice invoice = new Invoice();


### PR DESCRIPTION
Based on https://github.com/spring-cloud/spring-cloud-openfeign/issues/440#issuecomment-776979189, also see #385

I've implemented `PageableSpringQueryMapEncoder` which processes `Pageable`, `Sort` which annotated as `@SpringQueryMap` to use with `@RequestBody`, along with tests.

Usage:

```java
@RequestMapping(value = "invoicesPagedWithBody", method = RequestMethod.POST,
		consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
ResponseEntity<Page<Invoice>> getInvoicesPagedWithBody(
		@SpringQueryMap org.springframework.data.domain.Pageable pageable, @RequestBody String titlePrefix);
```

I think I should make PR to branch 2.2.x also, so please notify me if needed.