### PR TITLE
Simplify Log.info logic

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
@@ -373,12 +373,9 @@ public class FeignClientFactoryBean implements FactoryBean<Object>, Initializing
 		Feign.Builder builder = feign(context);
 
 		if (!StringUtils.hasText(url)) {
-			if (url != null && LOG.isInfoEnabled()) {
-				LOG.info(
-						"The provided URL is empty. Will try picking an instance via load-balancing.");
-			}
-			else if (LOG.isDebugEnabled()) {
-				LOG.debug("URL not provided. Will use LoadBalancer.");
+
+			if (LOG.isInfoEnabled()) {
+				LOG.info("For '" + name + "' URL not provided. Will try picking an instance via load-balancing.");
 			}
 			if (!name.startsWith("http")) {
 				url = "http://" + name;


### PR DESCRIPTION
'url' is never null in given case. At least I think so. Even if I'm wrong there is no need to distinguish between null and empty. Goal is simple: Inform reader that feign is created with load-balancer, not with url.