### PR TITLE
Fix for RetryableFeignBlockingLoadBalancerClient closes stream 

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/LoadBalancerResponseStatusCodeException.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/LoadBalancerResponseStatusCodeException.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.loadbalancer;
+
+import feign.Response;
+import org.springframework.cloud.client.loadbalancer.RetryableStatusCodeException;
+
+import java.io.ByteArrayInputStream;
+import java.net.URI;
+
+/**
+ * A {@link RetryableStatusCodeException} for {@link Response}s.
+ *
+ * @author Ryan Baxter
+ */
+public class LoadBalancerResponseStatusCodeException extends RetryableStatusCodeException {
+
+	private final Response response;
+
+	public LoadBalancerResponseStatusCodeException(String serviceId, Response response,
+												   byte[] body, URI uri) {
+		super(serviceId, response.status(), response, uri);
+		this.response = Response.builder()
+				.body(new ByteArrayInputStream(body), body.length)
+				.headers(response.headers()).reason(response.reason())
+				.status(response.status()).request(response.request()).build();
+	}
+
+	@Override
+	public Response getResponse() {
+		return this.response;
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/loadbalancer/RetryableFeignBlockingLoadBalancerClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/loadbalancer/RetryableFeignBlockingLoadBalancerClientTests.java
@@ -16,7 +16,7 @@
 
 package org.springframework.cloud.openfeign.loadbalancer;
 
-import java.io.IOException;
+import java.io.*;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
@@ -27,6 +27,7 @@ import java.util.Map;
 import feign.Client;
 import feign.Request;
 import feign.Response;
+import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -113,6 +114,13 @@ class RetryableFeignBlockingLoadBalancerClientTests {
 		return Response.builder().request(testRequest()).status(status).build();
 	}
 
+	private Response testResponse(int status, String body) {
+		// ByteArrayInputStream ignores close() and must be wrapped
+		InputStream reallyCloseable = new BufferedInputStream(new ByteArrayInputStream(body.getBytes(StandardCharsets.UTF_8)));
+		return Response.builder().request(testRequest()).status(status).body(reallyCloseable, null).build();
+
+	}
+
 	@Test
 	void shouldExecuteOriginalRequestIfInstanceNotFound() throws IOException {
 		Request request = testRequest();
@@ -147,6 +155,27 @@ class RetryableFeignBlockingLoadBalancerClientTests {
 				URI.create("http://test/path"));
 		verify(delegate, times(2)).execute(any(), any());
 	}
+
+	@Test
+	void shouldExposeResponseBodyOnRetry() throws IOException {
+		properties.getRetryableStatusCodes().add(503);
+		Request request = testRequest();
+		when(delegate.execute(any(), any()))
+			.thenReturn(testResponse(503, "foo"), testResponse(503, "foo"));
+		when(retryFactory.createRetryPolicy(any(), eq(loadBalancerClient)))
+			.thenReturn(new BlockingLoadBalancedRetryPolicy("test",
+				loadBalancerClient, properties));
+		when(loadBalancerClient.reconstructURI(serviceInstance,
+			URI.create("http://test/path")))
+			.thenReturn(URI.create("http://testhost:80/path"));
+
+		Response response = feignBlockingLoadBalancerClient.execute(request, new Request.Options());
+
+		String bodyContent = IOUtils.toString(response.body().asReader(StandardCharsets.UTF_8));
+		assertThat(bodyContent).isEqualTo("foo");
+	}
+
+
 
 	@Test
 	void shouldPassCorrectRequestToDelegate() throws IOException {


### PR DESCRIPTION
and and losts response content

Code copied from Ribbon Client

Fix for https://github.com/spring-cloud/spring-cloud-openfeign/issues/568