### PR TITLE
Respect SpringDataWebProperties where possible

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -71,6 +71,7 @@ import static feign.form.ContentType.MULTIPART;
  * @author Jonatan Ivanov
  * @author Olga Maciaszek-Sharma
  * @author Hyeonmin Park
+ * @author Yanming Zhou
  */
 @Configuration(proxyBeanMethods = false)
 public class FeignClientsConfiguration {
@@ -130,7 +131,13 @@ public class FeignClientsConfiguration {
 	@ConditionalOnClass(name = "org.springframework.data.domain.Pageable")
 	@ConditionalOnMissingBean
 	public QueryMapEncoder feignQueryMapEncoderPageable() {
-		return new PageableSpringQueryMapEncoder();
+		PageableSpringQueryMapEncoder queryMapEncoder = new PageableSpringQueryMapEncoder();
+		if (springDataWebProperties != null) {
+			queryMapEncoder.setPageParameter(springDataWebProperties.getPageable().getPageParameter());
+			queryMapEncoder.setSizeParameter(springDataWebProperties.getPageable().getSizeParameter());
+			queryMapEncoder.setSortParameter(springDataWebProperties.getSort().getSortParameter());
+		}
+		return queryMapEncoder;
 	}
 
 	@Bean

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringEncoder.java
@@ -32,6 +32,7 @@ import org.springframework.data.domain.Sort;
  * Provides support for encoding spring Pageable via composition.
  *
  * @author Pascal Büttiker
+ * @author Yanming Zhou
  */
 public class PageableSpringEncoder implements Encoder {
 
@@ -82,8 +83,8 @@ public class PageableSpringEncoder implements Encoder {
 				Pageable pageable = (Pageable) object;
 
 				if (pageable.isPaged()) {
-					template.query(pageParameter, pageable.getPageNumber() + "");
-					template.query(sizeParameter, pageable.getPageSize() + "");
+					template.query(pageParameter, String.valueOf(pageable.getPageNumber()));
+					template.query(sizeParameter, String.valueOf(pageable.getPageSize()));
 				}
 
 				if (pageable.getSort() != null) {

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
@@ -31,9 +31,37 @@ import org.springframework.data.domain.Sort;
  * {@link org.springframework.cloud.openfeign.SpringQueryMap}.
  *
  * @author Hyeonmin Park
+ * @author Yanming Zhou
  * @since 2.2.8
  */
 public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
+
+	/**
+	 * Page index parameter name.
+	 */
+	private String pageParameter = "page";
+
+	/**
+	 * Page size parameter name.
+	 */
+	private String sizeParameter = "size";
+
+	/**
+	 * Sort parameter name.
+	 */
+	private String sortParameter = "sort";
+
+	public void setPageParameter(String pageParameter) {
+		this.pageParameter = pageParameter;
+	}
+
+	public void setSizeParameter(String sizeParameter) {
+		this.sizeParameter = sizeParameter;
+	}
+
+	public void setSortParameter(String sortParameter) {
+		this.sortParameter = sortParameter;
+	}
 
 	@Override
 	public Map<String, Object> encode(Object object) {
@@ -44,8 +72,8 @@ public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
 				Pageable pageable = (Pageable) object;
 
 				if (pageable.isPaged()) {
-					queryMap.put("page", pageable.getPageNumber());
-					queryMap.put("size", pageable.getPageSize());
+					queryMap.put(pageParameter, pageable.getPageNumber());
+					queryMap.put(sizeParameter, pageable.getPageSize());
 				}
 
 				if (pageable.getSort() != null) {
@@ -69,7 +97,7 @@ public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
 			sortQueries.add(order.getProperty() + "%2C" + order.getDirection());
 		}
 		if (!sortQueries.isEmpty()) {
-			queryMap.put("sort", sortQueries);
+			queryMap.put(sortParameter, sortQueries);
 		}
 	}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageableEncoderWithSpringDataWebTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageableEncoderWithSpringDataWebTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.support;
+
+import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * Tests the pagination encoding and sorting.
+ *
+ * @author Yanming Zhou
+ */
+@EnableConfigurationProperties(SpringDataWebProperties.class)
+@SpringBootTest(classes = SpringEncoderTests.Application.class, webEnvironment = RANDOM_PORT,
+		value = { "spring.application.name=springencodertest", "spring.jmx.enabled=false",
+				"spring.data.web.pageable.pageParameter=pageNo", "spring.data.web.pageable.sizeParameter=pageSize",
+				"spring.data.web.sort.sortParameter=orderBy" })
+public class PageableEncoderWithSpringDataWebTests extends PageableEncoderTests {
+
+	@Override
+	protected String getPageParameter() {
+		return "pageNo";
+	}
+
+	@Override
+	protected String getSizeParameter() {
+		return "pageSize";
+	}
+
+	@Override
+	protected String getSortParameter() {
+		return "orderBy";
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoderTests.java
@@ -16,8 +16,10 @@
 
 package org.springframework.cloud.openfeign.support;
 
-import feign.RequestTemplate;
-import feign.codec.Encoder;
+import java.util.List;
+import java.util.Map;
+
+import feign.QueryMapEncoder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -36,14 +38,13 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 /**
  * Tests the pagination encoding and sorting.
  *
- * @author Charlie Mordant.
  * @author Yanming Zhou
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringBootTest(classes = SpringEncoderTests.Application.class, webEnvironment = RANDOM_PORT,
 		value = { "spring.application.name=springencodertest", "spring.jmx.enabled=false" })
 @DirtiesContext
-public class PageableEncoderTests {
+public class PageableSpringQueryMapEncoderTests {
 
 	public static final int PAGE = 1;
 
@@ -70,19 +71,14 @@ public class PageableEncoderTests {
 
 	@Test
 	public void testPaginationAndSortingRequest() {
-		Encoder encoder = this.context.getInstance("foo", Encoder.class);
+		QueryMapEncoder encoder = this.context.getInstance("foo", QueryMapEncoder.class);
 		assertThat(encoder).isNotNull();
-		RequestTemplate request = new RequestTemplate();
-		encoder.encode(createPageAndSortRequest(), null, request);
 
-		// Request queries shall contain three entries
-		assertThat(request.queries()).hasSize(3);
-		// Request page shall contain page
-		assertThat(request.queries().get(getPageParameter())).contains(String.valueOf(PAGE));
-		// Request size shall contain size
-		assertThat(request.queries().get(getSizeParameter())).contains(String.valueOf(SIZE));
-		// Request sort size shall contain sort entries
-		assertThat(request.queries().get(getSortParameter())).hasSize(2);
+		Map<String, Object> map = encoder.encode(createPageAndSortRequest());
+		assertThat(map).hasSize(3);
+		assertThat((Integer) map.get(getPageParameter())).isEqualTo(PAGE);
+		assertThat((Integer) map.get(getSizeParameter())).isEqualTo(SIZE);
+		assertThat((List<?>) map.get(getSortParameter())).hasSize(2);
 	}
 
 	private Pageable createPageAndSortRequest() {
@@ -91,17 +87,14 @@ public class PageableEncoderTests {
 
 	@Test
 	public void testPaginationRequest() {
-		Encoder encoder = this.context.getInstance("foo", Encoder.class);
+		QueryMapEncoder encoder = this.context.getInstance("foo", QueryMapEncoder.class);
 		assertThat(encoder).isNotNull();
-		RequestTemplate request = new RequestTemplate();
-		encoder.encode(createPageAndRequest(), null, request);
-		assertThat(request.queries().size()).isEqualTo(2);
-		// Request page shall contain page
-		assertThat(request.queries().get(getPageParameter())).contains(String.valueOf(PAGE));
-		// Request size shall contain size
-		assertThat(request.queries().get(getSizeParameter())).contains(String.valueOf(SIZE));
-		// Request sort size shall contain sort entries
-		assertThat(request.queries()).doesNotContainKey(getSortParameter());
+
+		Map<String, Object> map = encoder.encode(createPageAndRequest());
+		assertThat(map).hasSize(2);
+		assertThat((Integer) map.get(getPageParameter())).isEqualTo(PAGE);
+		assertThat((Integer) map.get(getSizeParameter())).isEqualTo(SIZE);
+		assertThat(map).doesNotContainKey(getSortParameter());
 	}
 
 	private Pageable createPageAndRequest() {
@@ -110,15 +103,12 @@ public class PageableEncoderTests {
 
 	@Test
 	public void testSortingRequest() {
-		Encoder encoder = this.context.getInstance("foo", Encoder.class);
+		QueryMapEncoder encoder = this.context.getInstance("foo", QueryMapEncoder.class);
 		assertThat(encoder).isNotNull();
-		RequestTemplate request = new RequestTemplate();
 
-		encoder.encode(createSort(), null, request);
-		// Request queries shall contain three entries
-		assertThat(request.queries().size()).isEqualTo(1);
-		// Request sort size shall contain sort entries
-		assertThat(request.queries().get(getSortParameter())).hasSize(2);
+		Map<String, Object> map = encoder.encode(createSort());
+		assertThat(map).hasSize(1);
+		assertThat((List<?>) map.get(getSortParameter())).hasSize(2);
 	}
 
 	private Sort createSort() {
@@ -127,13 +117,11 @@ public class PageableEncoderTests {
 
 	@Test
 	public void testUnpagedRequest() {
-		Encoder encoder = this.context.getInstance("foo", Encoder.class);
+		QueryMapEncoder encoder = this.context.getInstance("foo", QueryMapEncoder.class);
 		assertThat(encoder).isNotNull();
-		RequestTemplate request = new RequestTemplate();
 
-		encoder.encode(Pageable.unpaged(), null, request);
-		// Request queries shall contain three entries
-		assertThat(request.queries()).isEmpty();
+		Map<String, Object> map = encoder.encode(Pageable.unpaged());
+		assertThat(map).isEmpty();
 	}
 
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoderWithSpringDataWebTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoderWithSpringDataWebTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.support;
+
+import org.springframework.boot.autoconfigure.data.web.SpringDataWebProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+/**
+ * Tests the pagination encoding and sorting.
+ *
+ * @author Yanming Zhou
+ */
+@EnableConfigurationProperties(SpringDataWebProperties.class)
+@SpringBootTest(classes = SpringEncoderTests.Application.class, webEnvironment = RANDOM_PORT,
+		value = { "spring.application.name=springencodertest", "spring.jmx.enabled=false",
+				"spring.data.web.pageable.pageParameter=pageNo", "spring.data.web.pageable.sizeParameter=pageSize",
+				"spring.data.web.sort.sortParameter=orderBy" })
+public class PageableSpringQueryMapEncoderWithSpringDataWebTests extends PageableSpringQueryMapEncoderTests {
+
+	@Override
+	protected String getPageParameter() {
+		return "pageNo";
+	}
+
+	@Override
+	protected String getSizeParameter() {
+		return "pageSize";
+	}
+
+	@Override
+	protected String getSortParameter() {
+		return "orderBy";
+	}
+
+}


### PR DESCRIPTION
`PageableSpringQueryMapEncoder` should use parameter names from `SpringDataWebProperties` if customized as well as `PageableSpringEncoder`