### PR TITLE
Support size = 0 in PageJacksonModule

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageJacksonModule.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageJacksonModule.java
@@ -65,18 +65,23 @@ public class PageJacksonModule extends Module {
 
 		private final Page<T> delegate;
 
-		SimplePageImpl(@JsonProperty("content") List<T> content, @JsonProperty("number") int number,
-				@JsonProperty("size") int size, @JsonProperty("totalElements") @JsonAlias({ "total-elements",
-						"total_elements", "totalelements", "TotalElements" }) long totalElements,
-				@JsonProperty("sort") Sort sort) {
-			PageRequest pageRequest;
-			if (sort != null) {
-				pageRequest = PageRequest.of(number, size, sort);
+		SimplePageImpl(@JsonProperty("content") List<T> content,
+					   @JsonProperty("number") int number,
+					   @JsonProperty("size") int size,
+					   @JsonProperty("totalElements") long totalElements,
+					   @JsonProperty("sort") Sort sort) {
+
+			if (size > 0) {
+				PageRequest pageRequest;
+				if (sort != null) {
+					pageRequest = PageRequest.of(number, size, sort);
+				} else {
+					pageRequest = PageRequest.of(number, size);
+				}
+				delegate = new PageImpl<>(content, pageRequest, totalElements);
+			} else {
+				delegate = new PageImpl<>(content);
 			}
-			else {
-				pageRequest = PageRequest.of(number, size);
-			}
-			delegate = new PageImpl<>(content, pageRequest, totalElements);
 
 		}
 


### PR DESCRIPTION
The current implementation raises an error when size equals 0. This behavior is incorrect because Page API allows this to happen. So I propose to check first the size of the implementation.