### PR TITLE
GitHub workflows: Use Java version in matrix, cache functionality of actions/setup-java@v2

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -21,16 +21,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up JDK ${{ matrix.java }}
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v2
         with:
+          distribution: 'zulu'
           java-version: ${{ matrix.java }}
-      - name: Cache local Maven repository
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+          cache: 'maven'
       - name: Build with Maven
         run: ./mvnw clean install -B -U -P sonar
       - uses: codecov/codecov-action@v1


### PR DESCRIPTION
Currently, GitHub workflow does define the matrix of Java versions, but not use them at all. So I've fixed it along with a simplicity improvement.

References:

* https://github.com/actions/setup-java#testing-against-different-java-versions
* https://github.com/actions/setup-java#caching-maven-dependencies