### PR TITLE
Extend FeignCircuitBreaker builder

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignCircuitBreaker.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignCircuitBreaker.java
@@ -16,8 +16,22 @@
 
 package org.springframework.cloud.openfeign;
 
+import feign.Capability;
+import feign.Client;
+import feign.Contract;
+import feign.ExceptionPropagationPolicy;
 import feign.Feign;
+import feign.InvocationHandlerFactory;
+import feign.Logger;
+import feign.QueryMapEncoder;
+import feign.Request;
+import feign.RequestInterceptor;
+import feign.ResponseMapper;
+import feign.Retryer;
 import feign.Target;
+import feign.codec.Decoder;
+import feign.codec.Encoder;
+import feign.codec.ErrorDecoder;
 
 import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
 import org.springframework.cloud.client.circuitbreaker.CircuitBreakerFactory;
@@ -87,6 +101,96 @@ public final class FeignCircuitBreaker {
 		@Override
 		public <T> T target(Target<T> target) {
 			return build(null).newInstance(target);
+		}
+
+		@Override
+		public Feign.Builder logLevel(Logger.Level logLevel) {
+			return super.logLevel(logLevel);
+		}
+
+		@Override
+		public Feign.Builder contract(Contract contract) {
+			return super.contract(contract);
+		}
+
+		@Override
+		public Feign.Builder client(Client client) {
+			return super.client(client);
+		}
+
+		@Override
+		public Feign.Builder retryer(Retryer retryer) {
+			return super.retryer(retryer);
+		}
+
+		@Override
+		public Feign.Builder logger(Logger logger) {
+			return super.logger(logger);
+		}
+
+		@Override
+		public Feign.Builder encoder(Encoder encoder) {
+			return super.encoder(encoder);
+		}
+
+		@Override
+		public Feign.Builder decoder(Decoder decoder) {
+			return super.decoder(decoder);
+		}
+
+		@Override
+		public Feign.Builder queryMapEncoder(QueryMapEncoder queryMapEncoder) {
+			return super.queryMapEncoder(queryMapEncoder);
+		}
+
+		@Override
+		public Feign.Builder mapAndDecode(ResponseMapper mapper, Decoder decoder) {
+			return super.mapAndDecode(mapper, decoder);
+		}
+
+		@Override
+		public Feign.Builder decode404() {
+			return super.decode404();
+		}
+
+		@Override
+		public Feign.Builder errorDecoder(ErrorDecoder errorDecoder) {
+			return super.errorDecoder(errorDecoder);
+		}
+
+		@Override
+		public Feign.Builder options(Request.Options options) {
+			return super.options(options);
+		}
+
+		@Override
+		public Feign.Builder requestInterceptor(RequestInterceptor requestInterceptor) {
+			return super.requestInterceptor(requestInterceptor);
+		}
+
+		@Override
+		public Feign.Builder requestInterceptors(Iterable<RequestInterceptor> requestInterceptors) {
+			return super.requestInterceptors(requestInterceptors);
+		}
+
+		@Override
+		public Feign.Builder invocationHandlerFactory(InvocationHandlerFactory invocationHandlerFactory) {
+			return super.invocationHandlerFactory(invocationHandlerFactory);
+		}
+
+		@Override
+		public Feign.Builder doNotCloseAfterDecode() {
+			return super.doNotCloseAfterDecode();
+		}
+
+		@Override
+		public Feign.Builder exceptionPropagationPolicy(ExceptionPropagationPolicy propagationPolicy) {
+			return super.exceptionPropagationPolicy(propagationPolicy);
+		}
+
+		@Override
+		public Feign.Builder addCapability(Capability capability) {
+			return super.addCapability(capability);
 		}
 
 		public Feign build(final FallbackFactory<?> nullableFallbackFactory) {


### PR DESCRIPTION
Background
=====

In December 2020, this project got support for
[Spring Cloud CircuitBreaker](https://github.com/spring-cloud/spring-cloud-openfeign/commit/63a524843d3cfb9c6c1de45ca6cff5e1ea6e6a26).

At the same time, [Hystrix support](https://github.com/spring-cloud/spring-cloud-openfeign/commit/63a524843d3cfb9c6c1de45ca6cff5e1ea6e6a26#diff-c296f2567f513e037087d5f9d6f44acf6752e6b066088447d99fccde837fb0cfL53-L57)
was removed.

Problem
=====

In cases where people were creating the `HystrixFeignClient` manually
using the `HystrixFeignBuilder`, and overriding properties such as
`encoder(Encoder encoder)`, the new alternative does not support it.

Example of the code working before:

```java
HystrixFeign.builder()
            .encoder(jacksonEncoder)
            .decoder(jacksonDecoder)
            .target(MyClient.class, "https://api.my-url.com/", myFallback);
```

Currently, this is not supported, as the `FeignCircuitBreaker` does
not override `encoder`, `decoder`, among others.

Goal
======

To reestablish the previous functionality, so users can still create
the Feign clients programmatically, while using custom encoders, and
benefit from the circuit breaker.