### PR TITLE
Allow to inject custom HttpClient to programmatically created FeignClients

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
@@ -69,6 +69,7 @@ import org.springframework.util.StringUtils;
  * @author Sam Kruglov
  * @author Jasbir Singh
  * @author Hyeonmin Park
+ * @author Felix Dittrich
  */
 public class FeignClientFactoryBean
 		implements FactoryBean<Object>, InitializingBean, ApplicationContextAware, BeanFactoryAware {
@@ -132,7 +133,6 @@ public class FeignClientFactoryBean
 		// @formatter:on
 
 		configureFeign(context, builder);
-		applyBuildCustomizers(context, builder);
 
 		return builder;
 	}
@@ -443,6 +443,9 @@ public class FeignClientFactoryBean
 			}
 			builder.client(client);
 		}
+
+		applyBuildCustomizers(context, builder);
+
 		Targeter targeter = get(context, Targeter.class);
 		return (T) targeter.target(this, builder, context, new HardCodedTarget<>(type, name, url));
 	}


### PR DESCRIPTION
The call of applyBuildCustomizers has been done before applying the HttpClient from FeignContext.
This PR moves the call at the end of the getTarget Method. It will allow to use a custom HttpClient. See #671 for more details.

Follow Up PR for #672 (rebased on 3.1.x branch)

Move Call of ```applyBuildCustomizers()``` at end of ```getTarget()``` method.
Add Unit Test to verify custom HttpClients are set.
Modify Unit Tests to use ```getTarget()``` method instead of ```feign()``` method. ```feign()``` method has protected access and is only used within test scope. All other access happens through ```getTarget()``` method

fixes gh-671