### PR TITLE
Update appendix link in spring-cloud-openfeign doc

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -817,4 +817,4 @@ spring.cloud.openfeign.oauth2.load-balanced=true
 
 == Configuration properties
 
-To see the list of all Spring Cloud OpenFeign related configuration properties please check link:appendix.html[the Appendix page].
+To see the list of all Spring Cloud OpenFeign related configuration properties please check link:appendix.adoc[the Appendix page].


### PR DESCRIPTION
Current appendix link redirect to a 404 page