### PR TITLE
Delete '/' at the end of url

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
@@ -117,6 +117,9 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 			if (!url.contains("://")) {
 				url = "http://" + url;
 			}
+			if (url.endsWith("/")) {
+				url = url.substring(0, url.length() - 1);
+			}
 			try {
 				new URL(url);
 			}


### PR DESCRIPTION
In situation when we create FeignClient in this way:
@FeignClient(url = "https://localhost/", path = "api/v2")
We will get an error because of adding '/' in the beginning of the path in FeignClientsRegistrar.getPath, result will:
https://localhost//api/v2
To escape this situation we need to delete '/' at the end of url in FeignClientsRegistrar.getUrl