### PR TITLE
Fix a typo in sample code

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -385,7 +385,7 @@ For example, if you had this Feign client
 
 [source,java,indent=0]
 ----
-@FeignClienturl = "http://localhost:8080")
+@FeignClient(url = "http://localhost:8080")
 public interface DemoClient {
 
     @GetMapping("demo")


### PR DESCRIPTION
I found a typo in the latest release.
It should be `@FeignClient(url = "http://localhost:8080")`