### PR TITLE
add support pojo type for RequestParamParameterProcessor

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/RequestParamParameterProcessor.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/RequestParamParameterProcessor.java
@@ -23,6 +23,7 @@ import java.util.Map;
 
 import feign.MethodMetadata;
 
+import feign.form.util.PojoUtil;
 import org.springframework.cloud.openfeign.AnnotatedParameterProcessor;
 import org.springframework.web.bind.annotation.RequestParam;
 
@@ -51,7 +52,7 @@ public class RequestParamParameterProcessor implements AnnotatedParameterProcess
 		Class<?> parameterType = method.getParameterTypes()[parameterIndex];
 		MethodMetadata data = context.getMethodMetadata();
 
-		if (Map.class.isAssignableFrom(parameterType)) {
+		if (Map.class.isAssignableFrom(parameterType) || PojoUtil.isUserPojo(parameterType)) {
 			checkState(data.queryMapIndex() == null, "Query map can only be present once.");
 			data.queryMapIndex(parameterIndex);
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
@@ -546,6 +546,18 @@ class SpringMvcContractTests {
 	}
 
 	@Test
+	void testProcessQueryObject() throws Exception {
+		Method method = TestTemplate_QueryMap.class.getDeclaredMethod("queryObject", TestObject.class, String.class);
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/queryObject?aParam=" + "{aParam}");
+		assertThat(data.template().method()).isEqualTo("GET");
+		assertThat(data.queryMapIndex().intValue()).isEqualTo(0);
+		Map<String, Collection<String>> params = data.template().queries();
+		assertThat(params.get("aParam").iterator().next()).isEqualTo("{aParam}");
+	}
+
+	@Test
 	void testProcessQueryMapMoreThanOnce() throws Exception {
 		Method method = TestTemplate_QueryMap.class.getDeclaredMethod("queryMapMoreThanOnce", MultiValueMap.class,
 				MultiValueMap.class);
@@ -752,6 +764,8 @@ class SpringMvcContractTests {
 		@GetMapping("/queryMapObject")
 		String queryMapObject(@SpringQueryMap TestObject queryMap, @RequestParam(name = "aParam") String aParam);
 
+		@GetMapping("/queryObject")
+		String queryObject(@RequestParam TestObject queryMap, @RequestParam(name = "aParam") String aParam);
 	}
 
 	public interface TestTemplate_RequestPart {


### PR DESCRIPTION
The RequestParam annotation supports pojo type parameter parsing.