### PR TITLE
Customize load balanced requests according to the chosen ServiceInstance

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -815,6 +815,33 @@ Sometimes, when load balancing is enabled for Feign clients, you may want to use
 spring.cloud.openfeign.oauth2.load-balanced=true
 ----
 
+=== Transform the load-balanced HTTP request
+
+You can use the selected `ServiceInstance` to transform the load-balanced HTTP Request.
+
+For `Request`, you need to implement and define `LoadBalancerFeignRequestTransformer` as follows:
+
+[source,java,indent=0]
+----
+	@Bean
+	public LoadBalancerFeignRequestTransformer transformer() {
+		return new LoadBalancerFeignRequestTransformer() {
+
+			@Override
+			public Request transformRequest(Request request, ServiceInstance instance) {
+				Map<String, Collection<String>> headers = new HashMap<>(request.headers());
+				headers.put("X-ServiceId", Collections.singletonList(instance.getServiceId()));
+				headers.put("X-InstanceId", Collections.singletonList(instance.getInstanceId()));
+				return Request.create(request.httpMethod(), request.url(), headers, request.body(), request.charset(),
+						request.requestTemplate());
+			}
+		};
+	}
+----
+
+If multiple transformers are defined, they are applied in the order in which Beans are defined.
+Alternatively, you can use `LoadBalancerFeignRequestTransformer.DEFAULT_ORDER` to specify the order.
+
 == Configuration properties
 
 To see the list of all Spring Cloud OpenFeign related configuration properties please check link:appendix.html[the Appendix page].

--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -819,7 +819,7 @@ spring.cloud.openfeign.oauth2.load-balanced=true
 
 You can use the selected `ServiceInstance` to transform the load-balanced HTTP Request.
 
-For `Request`, you need to implement and define `LoadBalancerFeignRequestTransformer` as follows:
+For `Request`, you need to implement and define `LoadBalancerFeignRequestTransformer`, as follows:
 
 [source,java,indent=0]
 ----
@@ -839,7 +839,7 @@ For `Request`, you need to implement and define `LoadBalancerFeignRequestTransfo
 	}
 ----
 
-If multiple transformers are defined, they are applied in the order in which Beans are defined.
+If multiple transformers are defined, they are applied in the order in which beans are defined.
 Alternatively, you can use `LoadBalancerFeignRequestTransformer.DEFAULT_ORDER` to specify the order.
 
 == Configuration properties

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/DefaultFeignLoadBalancerConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/DefaultFeignLoadBalancerConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.openfeign.loadbalancer;
 
+import java.util.List;
+
 import feign.Client;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
@@ -36,6 +38,7 @@ import org.springframework.context.annotation.Configuration;
  * that uses {@link Client.Default} under the hood.
  *
  * @author Olga Maciaszek-Sharma
+ * @author changjin wei(魏昌进)
  * @since 2.2.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -46,9 +49,10 @@ class DefaultFeignLoadBalancerConfiguration {
 	@ConditionalOnMissingBean
 	@Conditional(OnRetryNotEnabledCondition.class)
 	public Client feignClient(LoadBalancerClient loadBalancerClient,
-			LoadBalancerClientFactory loadBalancerClientFactory) {
+			LoadBalancerClientFactory loadBalancerClientFactory,
+			List<LoadBalancerFeignRequestTransformer> transformers) {
 		return new FeignBlockingLoadBalancerClient(new Client.Default(null, null), loadBalancerClient,
-				loadBalancerClientFactory);
+				loadBalancerClientFactory, transformers);
 	}
 
 	@Bean
@@ -58,9 +62,10 @@ class DefaultFeignLoadBalancerConfiguration {
 	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "true",
 			matchIfMissing = true)
 	public Client feignRetryClient(LoadBalancerClient loadBalancerClient,
-			LoadBalancedRetryFactory loadBalancedRetryFactory, LoadBalancerClientFactory loadBalancerClientFactory) {
+			LoadBalancedRetryFactory loadBalancedRetryFactory, LoadBalancerClientFactory loadBalancerClientFactory,
+			List<LoadBalancerFeignRequestTransformer> transformers) {
 		return new RetryableFeignBlockingLoadBalancerClient(new Client.Default(null, null), loadBalancerClient,
-				loadBalancedRetryFactory, loadBalancerClientFactory);
+				loadBalancedRetryFactory, loadBalancerClientFactory, transformers);
 	}
 
 }

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/HttpClient5FeignLoadBalancerConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/HttpClient5FeignLoadBalancerConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.openfeign.loadbalancer;
 
+import java.util.List;
+
 import feign.Client;
 import feign.hc5.ApacheHttp5Client;
 import org.apache.hc.client5.http.classic.HttpClient;
@@ -40,6 +42,7 @@ import org.springframework.context.annotation.Import;
  * that uses {@link ApacheHttp5Client} under the hood.
  *
  * @author Nguyen Ky Thanh
+ * @author changjin wei(魏昌进)
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(ApacheHttp5Client.class)
@@ -53,9 +56,11 @@ class HttpClient5FeignLoadBalancerConfiguration {
 	@ConditionalOnMissingBean
 	@Conditional(OnRetryNotEnabledCondition.class)
 	public Client feignClient(LoadBalancerClient loadBalancerClient, HttpClient httpClient5,
-			LoadBalancerClientFactory loadBalancerClientFactory) {
+			LoadBalancerClientFactory loadBalancerClientFactory,
+			List<LoadBalancerFeignRequestTransformer> transformers) {
 		Client delegate = new ApacheHttp5Client(httpClient5);
-		return new FeignBlockingLoadBalancerClient(delegate, loadBalancerClient, loadBalancerClientFactory);
+		return new FeignBlockingLoadBalancerClient(delegate, loadBalancerClient, loadBalancerClientFactory,
+				transformers);
 	}
 
 	@Bean
@@ -65,10 +70,11 @@ class HttpClient5FeignLoadBalancerConfiguration {
 	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "true",
 			matchIfMissing = true)
 	public Client feignRetryClient(LoadBalancerClient loadBalancerClient, HttpClient httpClient5,
-			LoadBalancedRetryFactory loadBalancedRetryFactory, LoadBalancerClientFactory loadBalancerClientFactory) {
+			LoadBalancedRetryFactory loadBalancedRetryFactory, LoadBalancerClientFactory loadBalancerClientFactory,
+			List<LoadBalancerFeignRequestTransformer> transformers) {
 		Client delegate = new ApacheHttp5Client(httpClient5);
 		return new RetryableFeignBlockingLoadBalancerClient(delegate, loadBalancerClient, loadBalancedRetryFactory,
-				loadBalancerClientFactory);
+				loadBalancerClientFactory, transformers);
 	}
 
 }

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/HttpClientFeignLoadBalancerConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/HttpClientFeignLoadBalancerConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.openfeign.loadbalancer;
 
+import java.util.List;
+
 import feign.Client;
 import feign.httpclient.ApacheHttpClient;
 import org.apache.http.client.HttpClient;
@@ -42,6 +44,7 @@ import org.springframework.context.annotation.Import;
  *
  * @author Olga Maciaszek-Sharma
  * @author Nguyen Ky Thanh
+ * @author changjin wei(魏昌进)
  * @since 2.2.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -57,9 +60,11 @@ class HttpClientFeignLoadBalancerConfiguration {
 	@ConditionalOnMissingBean
 	@Conditional(OnRetryNotEnabledCondition.class)
 	public Client feignClient(LoadBalancerClient loadBalancerClient, HttpClient httpClient,
-			LoadBalancerClientFactory loadBalancerClientFactory) {
+			LoadBalancerClientFactory loadBalancerClientFactory,
+			List<LoadBalancerFeignRequestTransformer> transformers) {
 		ApacheHttpClient delegate = new ApacheHttpClient(httpClient);
-		return new FeignBlockingLoadBalancerClient(delegate, loadBalancerClient, loadBalancerClientFactory);
+		return new FeignBlockingLoadBalancerClient(delegate, loadBalancerClient, loadBalancerClientFactory,
+				transformers);
 	}
 
 	@Bean
@@ -69,10 +74,11 @@ class HttpClientFeignLoadBalancerConfiguration {
 	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "true",
 			matchIfMissing = true)
 	public Client feignRetryClient(LoadBalancerClient loadBalancerClient, HttpClient httpClient,
-			LoadBalancedRetryFactory loadBalancedRetryFactory, LoadBalancerClientFactory loadBalancerClientFactory) {
+			LoadBalancedRetryFactory loadBalancedRetryFactory, LoadBalancerClientFactory loadBalancerClientFactory,
+			List<LoadBalancerFeignRequestTransformer> transformers) {
 		ApacheHttpClient delegate = new ApacheHttpClient(httpClient);
 		return new RetryableFeignBlockingLoadBalancerClient(delegate, loadBalancerClient, loadBalancedRetryFactory,
-				loadBalancerClientFactory);
+				loadBalancerClientFactory, transformers);
 	}
 
 }

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/LoadBalancerFeignRequestTransformer.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/LoadBalancerFeignRequestTransformer.java
@@ -35,6 +35,12 @@ public interface LoadBalancerFeignRequestTransformer {
 	 */
 	int DEFAULT_ORDER = 0;
 
+	/**
+	 * ServiceInstance to transform the load-balanced Request.
+	 * @param request Original request.
+	 * @param instance ServiceInstance returned from LoadBalancer.
+	 * @return New request or original request
+	 */
 	Request transformRequest(Request request, ServiceInstance instance);
 
 }

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/LoadBalancerFeignRequestTransformer.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/LoadBalancerFeignRequestTransformer.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.loadbalancer;
+
+import feign.Request;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.core.annotation.Order;
+
+/**
+ * Allows applications to transform the load-balanced {@link Request} given the chosen
+ * {@link org.springframework.cloud.client.ServiceInstance}.
+ *
+ * @author changjin wei(魏昌进)
+ */
+@Order(LoadBalancerFeignRequestTransformer.DEFAULT_ORDER)
+public interface LoadBalancerFeignRequestTransformer {
+
+	/**
+	 * Order for the {@link LoadBalancerFeignRequestTransformer}.
+	 */
+	int DEFAULT_ORDER = 0;
+
+	Request transformRequest(Request request, ServiceInstance instance);
+
+}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/LoadBalancerFeignRequestTransformer.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/LoadBalancerFeignRequestTransformer.java
@@ -36,7 +36,7 @@ public interface LoadBalancerFeignRequestTransformer {
 	int DEFAULT_ORDER = 0;
 
 	/**
-	 * ServiceInstance to transform the load-balanced Request.
+	 * Allows transforming load-balanced requests based on the provided {@link ServiceInstance}.
 	 * @param request Original request.
 	 * @param instance ServiceInstance returned from LoadBalancer.
 	 * @return New request or original request

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/OkHttpFeignLoadBalancerConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/OkHttpFeignLoadBalancerConfiguration.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.openfeign.loadbalancer;
 
+import java.util.List;
+
 import feign.Client;
 import feign.okhttp.OkHttpClient;
 
@@ -39,6 +41,7 @@ import org.springframework.context.annotation.Import;
  * that uses {@link OkHttpClient} under the hood.
  *
  * @author Olga Maciaszek-Sharma
+ * @author changjin wei(魏昌进)
  * @since 2.2.0
  */
 @Configuration(proxyBeanMethods = false)
@@ -53,9 +56,11 @@ class OkHttpFeignLoadBalancerConfiguration {
 	@ConditionalOnMissingBean
 	@Conditional(OnRetryNotEnabledCondition.class)
 	public Client feignClient(okhttp3.OkHttpClient okHttpClient, LoadBalancerClient loadBalancerClient,
-			LoadBalancerClientFactory loadBalancerClientFactory) {
+			LoadBalancerClientFactory loadBalancerClientFactory,
+			List<LoadBalancerFeignRequestTransformer> transformers) {
 		OkHttpClient delegate = new OkHttpClient(okHttpClient);
-		return new FeignBlockingLoadBalancerClient(delegate, loadBalancerClient, loadBalancerClientFactory);
+		return new FeignBlockingLoadBalancerClient(delegate, loadBalancerClient, loadBalancerClientFactory,
+				transformers);
 	}
 
 	@Bean
@@ -65,10 +70,11 @@ class OkHttpFeignLoadBalancerConfiguration {
 	@ConditionalOnProperty(value = "spring.cloud.loadbalancer.retry.enabled", havingValue = "true",
 			matchIfMissing = true)
 	public Client feignRetryClient(LoadBalancerClient loadBalancerClient, okhttp3.OkHttpClient okHttpClient,
-			LoadBalancedRetryFactory loadBalancedRetryFactory, LoadBalancerClientFactory loadBalancerClientFactory) {
+			LoadBalancedRetryFactory loadBalancedRetryFactory, LoadBalancerClientFactory loadBalancerClientFactory,
+			List<LoadBalancerFeignRequestTransformer> transformers) {
 		OkHttpClient delegate = new OkHttpClient(okHttpClient);
 		return new RetryableFeignBlockingLoadBalancerClient(delegate, loadBalancerClient, loadBalancedRetryFactory,
-				loadBalancerClientFactory);
+				loadBalancerClientFactory, transformers);
 	}
 
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/loadbalancer/FeignBlockingLoadBalancerClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/loadbalancer/FeignBlockingLoadBalancerClientTests.java
@@ -21,9 +21,11 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -66,6 +68,7 @@ import static org.mockito.Mockito.when;
  * {@link FeignBlockingLoadBalancerClient} and its delegates.
  *
  * @author Olga Maciaszek-Sharma
+ * @author changjin wei(魏昌进)
  * @see <a href=
  * "https://github.com/spring-cloud/spring-cloud-commons/blob/main/spring-cloud-loadbalancer/src/test/java/org/springframework/cloud/loadbalancer/blocking/client/BlockingLoadBalancerClientTests.java">BlockingLoadBalancerClientTests</a>
  */
@@ -80,8 +83,11 @@ class FeignBlockingLoadBalancerClientTests {
 
 	private final LoadBalancerProperties loadBalancerProperties = new LoadBalancerProperties();
 
+	private final List<LoadBalancerFeignRequestTransformer> transformers = Arrays.asList(new InstanceIdTransformer(),
+			new ServiceIdTransformer());
+
 	private final FeignBlockingLoadBalancerClient feignBlockingLoadBalancerClient = new FeignBlockingLoadBalancerClient(
-			delegate, loadBalancerClient, loadBalancerClientFactory);
+			delegate, loadBalancerClient, loadBalancerClientFactory, transformers);
 
 	@BeforeEach
 	void setUp() {
@@ -133,9 +139,11 @@ class FeignBlockingLoadBalancerClientTests {
 		Request actualRequest = captor.getValue();
 		assertThat(actualRequest.httpMethod()).isEqualTo(Request.HttpMethod.GET);
 		assertThat(actualRequest.url()).isEqualTo(url);
-		assertThat(actualRequest.headers()).hasSize(1);
+		assertThat(actualRequest.headers()).hasSize(3);
 		assertThat(actualRequest.headers()).containsEntry(HttpHeaders.CONTENT_TYPE,
 				Collections.singletonList(MediaType.APPLICATION_JSON_VALUE));
+		assertThat(actualRequest.headers()).containsEntry("X-ServiceId", Collections.singletonList("test"));
+		assertThat(actualRequest.headers()).containsEntry("X-InstanceId", Collections.singletonList("test-1"));
 		assertThat(new String(actualRequest.body())).isEqualTo("hello");
 	}
 
@@ -249,6 +257,30 @@ class FeignBlockingLoadBalancerClientTests {
 		@Override
 		protected String getName() {
 			return this.getClass().getSimpleName();
+		}
+
+	}
+
+	private static class InstanceIdTransformer implements LoadBalancerFeignRequestTransformer {
+
+		@Override
+		public Request transformRequest(Request request, ServiceInstance instance) {
+			Map<String, Collection<String>> headers = new HashMap<>(request.headers());
+			headers.put("X-InstanceId", Collections.singletonList(instance.getInstanceId()));
+			return Request.create(request.httpMethod(), request.url(), headers, request.body(), request.charset(),
+					request.requestTemplate());
+		}
+
+	}
+
+	private static class ServiceIdTransformer implements LoadBalancerFeignRequestTransformer {
+
+		@Override
+		public Request transformRequest(Request request, ServiceInstance instance) {
+			Map<String, Collection<String>> headers = new HashMap<>(request.headers());
+			headers.put("X-ServiceId", Collections.singletonList(instance.getServiceId()));
+			return Request.create(request.httpMethod(), request.url(), headers, request.body(), request.charset(),
+					request.requestTemplate());
 		}
 
 	}


### PR DESCRIPTION
Applications can define their own LoadBalancerFeignRequestTransformer beans
which can modify the Request to be executed. These beans can be
@Ordered in case of multiple transformers.


reference [Transform the load-balanced HTTP request]( https://docs.spring.io/spring-cloud-commons/docs/current/reference/html/#transform-the-load-balanced-http-request)