### PR TITLE
Disable loadbalancer clients retry when clients retry is disabled

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/RetryableFeignBlockingLoadBalancerClient.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/RetryableFeignBlockingLoadBalancerClient.java
@@ -231,7 +231,9 @@ public class RetryableFeignBlockingLoadBalancerClient implements Client {
 			retryTemplate.setListeners(retryListeners);
 		}
 
-		retryTemplate.setRetryPolicy(retryPolicy == null ? new NeverRetryPolicy()
+		retryTemplate.setRetryPolicy(
+			!loadBalancerClientFactory.getProperties(serviceId).getRetry().isEnabled() || retryPolicy == null
+				? new NeverRetryPolicy()
 				: new InterceptorRetryPolicy(toHttpRequest(request), retryPolicy, loadBalancerClient, serviceId));
 		return retryTemplate;
 	}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/loadbalancer/RetryableFeignBlockingLoadBalancerClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/loadbalancer/RetryableFeignBlockingLoadBalancerClientTests.java
@@ -20,7 +20,6 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -55,7 +54,6 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
-import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -171,13 +169,12 @@ class RetryableFeignBlockingLoadBalancerClientTests {
 	void shouldNotRetryOnDisabled() throws IOException {
 		properties.getRetry().setEnabled(false);
 		Request request = testRequest();
-		FeignException ex = connectTimedOutException(request);
-		when(delegate.execute(any(), any())).thenThrow(ex);
+		when(delegate.execute(any(), any())).thenThrow(new IOException());
 		when(retryFactory.createRetryPolicy(any(), eq(loadBalancerClient)))
 			.thenReturn(new BlockingLoadBalancedRetryPolicy(properties));
 
 		assertThatThrownBy(() -> feignBlockingLoadBalancerClient.execute(request, new Request.Options()))
-			.isInstanceOf(FeignException.class);
+			.isInstanceOf(IOException.class);
 
 		verify(delegate, times(1)).execute(any(), any());
 	}
@@ -278,17 +275,6 @@ class RetryableFeignBlockingLoadBalancerClientTests {
 		feignHeaders.put(HttpHeaders.CONTENT_TYPE, Collections.singletonList(MediaType.APPLICATION_JSON_VALUE));
 		return feignHeaders;
 
-	}
-
-	private FeignException connectTimedOutException(Request request) {
-		IOException ex = new SocketTimeoutException("Connect timed out");
-
-		return new RetryableException(
-			-1,
-			format("%s executing %s %s", ex.getMessage(), request.httpMethod(), request.url()),
-			request.httpMethod(),
-			ex,
-			null, request);
 	}
 
 	protected static class TestLoadBalancerLifecycle

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/loadbalancer/RetryableFeignBlockingLoadBalancerClientTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/loadbalancer/RetryableFeignBlockingLoadBalancerClientTests.java
@@ -20,6 +20,7 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -31,9 +32,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
-import feign.Client;
-import feign.Request;
-import feign.Response;
+import feign.*;
 import org.apache.commons.io.IOUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -56,7 +55,9 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
+import static java.lang.String.format;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
@@ -167,6 +168,22 @@ class RetryableFeignBlockingLoadBalancerClientTests {
 	}
 
 	@Test
+	void shouldNotRetryOnDisabled() throws IOException {
+		properties.getRetry().setEnabled(false);
+		Request request = testRequest();
+		FeignException ex = connectTimedOutException(request);
+		when(delegate.execute(any(), any())).thenThrow(ex);
+		when(retryFactory.createRetryPolicy(any(), eq(loadBalancerClient)))
+			.thenReturn(new BlockingLoadBalancedRetryPolicy(properties));
+
+		assertThatThrownBy(() -> feignBlockingLoadBalancerClient.execute(request, new Request.Options()))
+			.isInstanceOf(FeignException.class);
+
+		verify(delegate, times(1)).execute(any(), any());
+	}
+
+
+	@Test
 	void shouldExposeResponseBodyOnRetry() throws IOException {
 		properties.getRetry().getRetryableStatusCodes().add(503);
 		Request request = testRequest();
@@ -261,6 +278,17 @@ class RetryableFeignBlockingLoadBalancerClientTests {
 		feignHeaders.put(HttpHeaders.CONTENT_TYPE, Collections.singletonList(MediaType.APPLICATION_JSON_VALUE));
 		return feignHeaders;
 
+	}
+
+	private FeignException connectTimedOutException(Request request) {
+		IOException ex = new SocketTimeoutException("Connect timed out");
+
+		return new RetryableException(
+			-1,
+			format("%s executing %s %s", ex.getMessage(), request.httpMethod(), request.url()),
+			request.httpMethod(),
+			ex,
+			null, request);
 	}
 
 	protected static class TestLoadBalancerLifecycle


### PR DESCRIPTION
Hi, I wrote this PR because the load balancer client retry properties did not work as expected.

I have loadbalancer properties as below (1 default, 1 individual clients)

```yml
spring.cloud.loadbalancer:
  retry:
    enabled: true
    retryable-status-codes: 503
    max-retries-on-next-service-instance: 1

  clients:
    retry-disabled-service:
      retry:
        enabled: false
```

And I expect when I execute `retry-disabled-service` client it should not retry.
However, the client will do the retry as set in default properties.

I think the `enabled` property of that individual client retry should be checked. [reference](https://docs.spring.io/spring-cloud-commons/docs/current/reference/html/#retrying-failed-requests)
And I checked `spring.cloud.loadbalancer.clients.<clientId>.retry.enabled` is not checked when set `RetryPolicy` to `RetryTemplate`.

Therefore, I made this pull request with reference to [RetryLoadBalancerInterceptor#createRetryTemplate](https://github.com/spring-cloud/spring-cloud-commons/blob/main/spring-cloud-commons/src/main/java/org/springframework/cloud/client/loadbalancer/RetryLoadBalancerInterceptor.java#L163).
Plus, I added test, too.