### PR TITLE
Handle byte[] arrays correctly.(Fixes gh-741)

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/AbstractFormWriter.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/AbstractFormWriter.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.openfeign.support;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.util.Iterator;
 import java.util.function.Predicate;
 
@@ -32,6 +33,7 @@ import static feign.form.ContentProcessor.CRLF;
 
 /**
  * @author Darren Foong
+ * @author Wu Daifu
  */
 public abstract class AbstractFormWriter extends AbstractWriter {
 
@@ -61,10 +63,16 @@ public abstract class AbstractFormWriter extends AbstractWriter {
 	protected abstract String writeAsString(Object object) throws IOException;
 
 	private boolean isTypeOrCollection(Object object, Predicate<Object> isType) {
+		if (object == null) {
+			return false;
+		}
 		if (object.getClass().isArray()) {
-			Object[] array = (Object[]) object;
-
-			return array.length > 1 && isType.test(array[0]);
+			int len = Array.getLength(object);
+			if (len > 0) {
+				Object one = Array.get(object, 0);
+				return len > 1 && one != null && isType.test(one);
+			}
+			return false;
 		}
 		else if (object instanceof Iterable) {
 			Iterable<?> iterable = (Iterable<?>) object;

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/AbstractFormWriterTest.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/AbstractFormWriterTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.support;
+
+import java.io.IOException;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import org.springframework.cloud.openfeign.support.AbstractFormWriter;
+import org.springframework.http.MediaType;
+
+/**
+ * @author Wu Daifu
+ */
+public class AbstractFormWriterTest {
+
+	@Test
+	public void testIsApplicable() {
+		MockFormWriter formWriter = new MockFormWriter();
+		Object object = new Object();
+		Assertions.assertFalse(formWriter.isApplicable(object));
+		object = new Object[]{new Object(), new Object()};
+		Assertions.assertFalse(formWriter.isApplicable(object));
+		object = new UserPojo();
+		Assertions.assertTrue(formWriter.isApplicable(object));
+		object = new UserPojo[] {new UserPojo(), new UserPojo()};
+		Assertions.assertTrue(formWriter.isApplicable(object));
+		object = new byte[] {'1', '2'};
+		Assertions.assertFalse(formWriter.isApplicable(object));
+	}
+
+	class MockFormWriter extends AbstractFormWriter {
+
+		@Override
+		protected MediaType getContentType() {
+			return null;
+		}
+
+		@Override
+		protected String writeAsString(Object object) throws IOException {
+			return null;
+		}
+	}
+
+	class UserPojo {
+	}
+}
+

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/AbstractFormWriterTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/AbstractFormWriterTests.java
@@ -27,10 +27,10 @@ import org.springframework.http.MediaType;
 /**
  * @author Wu Daifu
  */
-public class AbstractFormWriterTest {
+class AbstractFormWriterTests {
 
 	@Test
-	public void testIsApplicable() {
+	void shouldCorrectlyResolveIfApplicableForCollection() {
 		MockFormWriter formWriter = new MockFormWriter();
 		Object object = new Object();
 		Assertions.assertFalse(formWriter.isApplicable(object));

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/AbstractFormWriterTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/AbstractFormWriterTests.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import org.springframework.cloud.openfeign.support.AbstractFormWriter;
 import org.springframework.http.MediaType;
 
 /**


### PR DESCRIPTION
Fixes #741

Make `AbstractFormWriter#isTypeOrCollection()` handle byte[] arrays correctly instead of casting byte[] to object[] directly.