### PR TITLE
refactor load balance client so that users can add their custom implementation

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
@@ -48,6 +48,7 @@ import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.cloud.openfeign.clientconfig.FeignClientConfigurer;
+import org.springframework.cloud.openfeign.loadbalancer.AbstractLoadBalancerClient;
 import org.springframework.cloud.openfeign.loadbalancer.FeignBlockingLoadBalancerClient;
 import org.springframework.cloud.openfeign.loadbalancer.RetryableFeignBlockingLoadBalancerClient;
 import org.springframework.context.ApplicationContext;
@@ -432,15 +433,10 @@ public class FeignClientFactoryBean
 		String url = this.url + cleanPath();
 		Client client = getOptional(context, Client.class);
 		if (client != null) {
-			if (client instanceof FeignBlockingLoadBalancerClient) {
+			if (client instanceof AbstractLoadBalancerClient) {
 				// not load balancing because we have a url,
 				// but Spring Cloud LoadBalancer is on the classpath, so unwrap
-				client = ((FeignBlockingLoadBalancerClient) client).getDelegate();
-			}
-			if (client instanceof RetryableFeignBlockingLoadBalancerClient) {
-				// not load balancing because we have a url,
-				// but Spring Cloud LoadBalancer is on the classpath, so unwrap
-				client = ((RetryableFeignBlockingLoadBalancerClient) client).getDelegate();
+				client = ((AbstractLoadBalancerClient) client).getDelegate();
 			}
 			builder.client(client);
 		}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientFactoryBean.java
@@ -49,8 +49,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.cloud.openfeign.clientconfig.FeignClientConfigurer;
 import org.springframework.cloud.openfeign.loadbalancer.AbstractLoadBalancerClient;
-import org.springframework.cloud.openfeign.loadbalancer.FeignBlockingLoadBalancerClient;
-import org.springframework.cloud.openfeign.loadbalancer.RetryableFeignBlockingLoadBalancerClient;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/AbstractLoadBalancerClient.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/AbstractLoadBalancerClient.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.loadbalancer;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.loadbalancer.DefaultRequest;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerLifecycle;
+import org.springframework.cloud.client.loadbalancer.LoadBalancerProperties;
+import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
+
+import feign.Client;
+import feign.Request;
+import feign.Request.Options;
+import feign.Response;
+
+/**
+ * An abstract {@link Client} implementation that uses {@link LoadBalancerClient} to select a
+ * {@link ServiceInstance} to use while resolving the request host.
+ * 
+ * @author liubao
+ */
+public abstract class AbstractLoadBalancerClient<T> implements Client {
+
+	protected final Client delegate;
+
+	protected final LoadBalancerClient loadBalancerClient;
+
+	protected final LoadBalancerClientFactory loadBalancerClientFactory;
+
+	protected AbstractLoadBalancerClient(Client delegate, LoadBalancerClient loadBalancerClient,
+			LoadBalancerClientFactory loadBalancerClientFactory) {
+		this.delegate = delegate;
+		this.loadBalancerClient = loadBalancerClient;
+		this.loadBalancerClientFactory = loadBalancerClientFactory;
+	}
+
+	protected Response executeWithLoadBalancerLifecycleProcessing(Options options, Request feignRequest,
+			Set<LoadBalancerLifecycle> supportedLifecycleProcessors, DefaultRequest<T> lbRequest,
+			org.springframework.cloud.client.loadbalancer.Response<ServiceInstance> lbResponse, boolean loadBalanced,
+			LoadBalancerProperties loadBalancerProperties) throws IOException {
+		return LoadBalancerUtils.executeWithLoadBalancerLifecycleProcessing(delegate, options, feignRequest, lbRequest,
+				lbResponse, supportedLifecycleProcessors, loadBalanced,
+				loadBalancerProperties.isUseRawStatusCodeInResponseData());
+	}
+
+	public Client getDelegate() {
+		return delegate;
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/AbstractLoadBalancerClient.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/AbstractLoadBalancerClient.java
@@ -19,6 +19,11 @@ package org.springframework.cloud.openfeign.loadbalancer;
 import java.io.IOException;
 import java.util.Set;
 
+import feign.Client;
+import feign.Request;
+import feign.Request.Options;
+import feign.Response;
+
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.loadbalancer.DefaultRequest;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerClient;
@@ -26,15 +31,10 @@ import org.springframework.cloud.client.loadbalancer.LoadBalancerLifecycle;
 import org.springframework.cloud.client.loadbalancer.LoadBalancerProperties;
 import org.springframework.cloud.loadbalancer.support.LoadBalancerClientFactory;
 
-import feign.Client;
-import feign.Request;
-import feign.Request.Options;
-import feign.Response;
-
 /**
  * An abstract {@link Client} implementation that uses {@link LoadBalancerClient} to select a
  * {@link ServiceInstance} to use while resolving the request host.
- * 
+ *
  * @author liubao
  */
 public abstract class AbstractLoadBalancerClient<T> implements Client {


### PR DESCRIPTION
>>> Why add this refactor ?
   
   My application need to add a custom Client like FeignBlockingLoadBalancerClient, e.g.

 ```
public class CustomFeignBlockingLoadBalancerClient implements Client {
   ...
}
```

This works pretty well when using load balanced clients. But when mix with load balanced and non load balanced clients, `FeignClientFactoryBean` hard coded to work with FeignBlockingLoadBalancerClient to get the delegate


```
		if (client != null) {
			if (client instanceof FeignBlockingLoadBalancerClient) {
				// not load balancing because we have a url,
				// but Spring Cloud LoadBalancer is on the classpath, so unwrap
				client = ((FeignBlockingLoadBalancerClient) client).getDelegate();
			}
			if (client instanceof RetryableFeignBlockingLoadBalancerClient) {
				// not load balancing because we have a url,
				// but Spring Cloud LoadBalancer is on the classpath, so unwrap
				client = ((RetryableFeignBlockingLoadBalancerClient) client).getDelegate();
			}
			builder.client(client);
		}
```

Refactor the code can help easier to customize FeignBlockingLoadBalancerClient and work with  non load balanced clients. 