### PR TITLE
LoadBalancerFeignRequestTransformer document description error

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -827,14 +827,6 @@ TIP:: Using the `serviceId` as OAuth2 client registrationId is convenient for lo
 
 TIP:: If you do not want to use the default setup for the `OAuth2AuthorizedClientManager`, you can just instantiate a bean of this type in your configuration.
 
-=== Transform the load-balanced HTTP request
-
-You can use the selected `ServiceInstance` to transform the load-balanced HTTP Request.
-
-For `Request`, you need to implement and define `LoadBalancerFeignRequestTransformer`, as follows:
-
-[source,java,indent=0]
-----
 
 == Configuration properties
 


### PR DESCRIPTION
1. Remove LoadBalancerFeignRequestTransformer
LoadBalancerFeignRequestTransformer is not merged into 3.1. X

2. Fix configuration properties format errors

[spring-cloud-openfeign/docs/current](https://docs.spring.io/spring-cloud-openfeign/docs/current/reference/html/#transform-the-load-balanced-http-request)

![image](https://user-images.githubusercontent.com/30821411/201035407-6790e0d1-614b-4bf9-aab4-f56ddf7b7ba5.png)

