### PR TITLE
Disable hostname verification when ssl validation is disabled.

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/clientconfig/HttpClient5FeignConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/clientconfig/HttpClient5FeignConfiguration.java
@@ -35,6 +35,7 @@ import org.apache.hc.client5.http.impl.classic.HttpClients;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.socket.LayeredConnectionSocketFactory;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactoryBuilder;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.http.ssl.TLS;
@@ -110,6 +111,7 @@ public class HttpClient5FeignConfiguration {
 				final SSLContext sslContext = SSLContext.getInstance("SSL");
 				sslContext.init(null, new TrustManager[] { new DisabledValidationTrustManager() }, new SecureRandom());
 				sslConnectionSocketFactoryBuilder.setSslContext(sslContext);
+				sslConnectionSocketFactoryBuilder.setHostnameVerifier(NoopHostnameVerifier.INSTANCE);
 			}
 			catch (NoSuchAlgorithmException | KeyManagementException e) {
 				LOG.warn("Error creating SSLContext", e);


### PR DESCRIPTION
Fixes gh-625.

Prior to Apache Http Client5 `org.springframework.cloud.commons.httpclient.DefaultApacheHttpClientConnectionManagerFactory` was being used which added the `NoopHostnameVerifier`.  See https://github.com/spring-cloud/spring-cloud-commons/blob/e72fc6c6906cab8dedd1277dccffb5aeca99aec6/spring-cloud-commons/src/main/java/org/springframework/cloud/commons/httpclient/DefaultApacheHttpClientConnectionManagerFactory.java#L69 

