### PR TITLE
connectionRequestTimeout for httpClient Fixes gh-799

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/clientconfig/HttpClient5FeignConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/clientconfig/HttpClient5FeignConfiguration.java
@@ -55,6 +55,7 @@ import org.springframework.context.annotation.Configuration;
  * Default configuration for {@link CloseableHttpClient}.
  *
  * @author Nguyen Ky Thanh
+ * @author changjin wei(魏昌进)
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnMissingBean(CloseableHttpClient.class)
@@ -90,7 +91,11 @@ public class HttpClient5FeignConfiguration {
 				.setDefaultRequestConfig(RequestConfig.custom()
 						.setConnectTimeout(
 								Timeout.of(httpClientProperties.getConnectionTimeout(), TimeUnit.MILLISECONDS))
-						.setRedirectsEnabled(httpClientProperties.isFollowRedirects()).build())
+						.setRedirectsEnabled(httpClientProperties.isFollowRedirects())
+						.setConnectionRequestTimeout(
+								Timeout.of(httpClientProperties.getHc5().getConnectionRequestTimeout(),
+										httpClientProperties.getHc5().getConnectionRequestTimeoutUnit()))
+						.build())
 				.build();
 		return httpClient5;
 	}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/FeignHttpClientProperties.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/FeignHttpClientProperties.java
@@ -27,6 +27,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * @author Ryan Baxter
  * @author Nguyen Ky Thanh
  * @author Olga Maciaszek-Sharma
+ * @author changjin wei(魏昌进)
  */
 @ConfigurationProperties(prefix = "feign.httpclient")
 public class FeignHttpClientProperties {
@@ -200,6 +201,16 @@ public class FeignHttpClientProperties {
 		public static final TimeUnit DEFAULT_SOCKET_TIMEOUT_UNIT = TimeUnit.SECONDS;
 
 		/**
+		 * Default value for connection request timeout.
+		 */
+		public static final int DEFAULT_CONNECTION_REQUEST_TIMEOUT = 3;
+
+		/**
+		 * Default value for connection request timeout unit.
+		 */
+		public static final TimeUnit DEFAULT_CONNECTION_REQUEST_TIMEOUT_UNIT = TimeUnit.MINUTES;
+
+		/**
 		 * Pool concurrency policies.
 		 */
 		private PoolConcurrencyPolicy poolConcurrencyPolicy = DEFAULT_POOL_CONCURRENCY_POLICY;
@@ -218,6 +229,16 @@ public class FeignHttpClientProperties {
 		 * Default value for socket timeout unit.
 		 */
 		private TimeUnit socketTimeoutUnit = DEFAULT_SOCKET_TIMEOUT_UNIT;
+
+		/**
+		 * Default value for connection request timeout.
+		 */
+		private int connectionRequestTimeout = DEFAULT_CONNECTION_REQUEST_TIMEOUT;
+
+		/**
+		 * Default value for connection request timeout unit.
+		 */
+		private TimeUnit connectionRequestTimeoutUnit = DEFAULT_CONNECTION_REQUEST_TIMEOUT_UNIT;
 
 		public PoolConcurrencyPolicy getPoolConcurrencyPolicy() {
 			return poolConcurrencyPolicy;
@@ -249,6 +270,22 @@ public class FeignHttpClientProperties {
 
 		public void setSocketTimeout(int socketTimeout) {
 			this.socketTimeout = socketTimeout;
+		}
+
+		public int getConnectionRequestTimeout() {
+			return connectionRequestTimeout;
+		}
+
+		public void setConnectionRequestTimeout(int connectionRequestTimeout) {
+			this.connectionRequestTimeout = connectionRequestTimeout;
+		}
+
+		public TimeUnit getConnectionRequestTimeoutUnit() {
+			return connectionRequestTimeoutUnit;
+		}
+
+		public void setConnectionRequestTimeoutUnit(TimeUnit connectionRequestTimeoutUnit) {
+			this.connectionRequestTimeoutUnit = connectionRequestTimeoutUnit;
 		}
 
 		/**

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/FeignHttpClientPropertiesTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/FeignHttpClientPropertiesTests.java
@@ -32,12 +32,15 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.cloud.openfeign.support.FeignHttpClientProperties.Hc5Properties.DEFAULT_CONNECTION_REQUEST_TIMEOUT;
+import static org.springframework.cloud.openfeign.support.FeignHttpClientProperties.Hc5Properties.DEFAULT_CONNECTION_REQUEST_TIMEOUT_UNIT;
 import static org.springframework.cloud.openfeign.support.FeignHttpClientProperties.Hc5Properties.DEFAULT_SOCKET_TIMEOUT;
 import static org.springframework.cloud.openfeign.support.FeignHttpClientProperties.Hc5Properties.DEFAULT_SOCKET_TIMEOUT_UNIT;
 
 /**
  * @author Ryan Baxter
  * @author Nguyen Ky Thanh
+ * @author changjin wei(魏昌进)
  */
 @DirtiesContext
 class FeignHttpClientPropertiesTests {
@@ -67,17 +70,23 @@ class FeignHttpClientPropertiesTests {
 		assertThat(getProperties().getHc5().getPoolReusePolicy()).isEqualTo(PoolReusePolicy.FIFO);
 		assertThat(getProperties().getHc5().getSocketTimeout()).isEqualTo(DEFAULT_SOCKET_TIMEOUT);
 		assertThat(getProperties().getHc5().getSocketTimeoutUnit()).isEqualTo(DEFAULT_SOCKET_TIMEOUT_UNIT);
+		assertThat(getProperties().getHc5().getConnectionRequestTimeout())
+				.isEqualTo(DEFAULT_CONNECTION_REQUEST_TIMEOUT);
+		assertThat(getProperties().getHc5().getConnectionRequestTimeoutUnit())
+				.isEqualTo(DEFAULT_CONNECTION_REQUEST_TIMEOUT_UNIT);
 	}
 
 	@Test
 	void testCustomization() {
 		TestPropertyValues
-				.of("feign.httpclient.maxConnections=2", "feign.httpclient.connectionTimeout=2",
+			.of("feign.httpclient.maxConnections=2", "feign.httpclient.connectionTimeout=2",
 						"feign.httpclient.maxConnectionsPerRoute=2", "feign.httpclient.timeToLive=2",
 						"feign.httpclient.disableSslValidation=true", "feign.httpclient.followRedirects=false",
 						"feign.httpclient.disableSslValidation=true", "feign.httpclient.followRedirects=false",
 						"feign.httpclient.hc5.poolConcurrencyPolicy=lax", "feign.httpclient.hc5.poolReusePolicy=lifo",
-						"feign.httpclient.hc5.socketTimeout=200", "feign.httpclient.hc5.socketTimeoutUnit=milliseconds")
+						"feign.httpclient.hc5.socketTimeout=200", "feign.httpclient.hc5.socketTimeoutUnit=milliseconds",
+						"feign.httpclient.hc5.connectionRequestTimeout=200",
+						"feign.httpclient.hc5.connectionRequestTimeoutUnit=milliseconds")
 				.applyTo(this.context);
 		setupContext();
 		assertThat(getProperties().getMaxConnections()).isEqualTo(2);
@@ -90,6 +99,8 @@ class FeignHttpClientPropertiesTests {
 		assertThat(getProperties().getHc5().getPoolReusePolicy()).isEqualTo(PoolReusePolicy.LIFO);
 		assertThat(getProperties().getHc5().getSocketTimeout()).isEqualTo(200);
 		assertThat(getProperties().getHc5().getSocketTimeoutUnit()).isEqualTo(TimeUnit.MILLISECONDS);
+		assertThat(getProperties().getHc5().getConnectionRequestTimeout()).isEqualTo(200);
+		assertThat(getProperties().getHc5().getConnectionRequestTimeoutUnit()).isEqualTo(TimeUnit.MILLISECONDS);
 	}
 
 	private void setupContext() {


### PR DESCRIPTION
Fixes issue [Can't config connection request timeout for http client #799](https://github.com/spring-cloud/spring-cloud-openfeign/issues/799) for 3.1.x