### PR TITLE
document requirements for decoders (+ others) specified via class in the config

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-openfeign.adoc
@@ -217,7 +217,7 @@ spring:
 						queryMapEncoder: com.example.SimpleQueryMapEncoder
 						micrometer.enabled: false
 ----
-`feignName` in this example refers to `@FeignClient` `value`, that is also aliased with `@FeignClient` `name` and `@FeignClient` `contextId`. In a load-balanced scenario, it also corresponds to the `serviceId` of the server app that will be used to retrieve the instances.
+`feignName` in this example refers to `@FeignClient` `value`, that is also aliased with `@FeignClient` `name` and `@FeignClient` `contextId`. In a load-balanced scenario, it also corresponds to the `serviceId` of the server app that will be used to retrieve the instances. The specified classes for decoders, retryer and other ones must have a bean in the Spring context or have a default constructor.
 
 
 Default configurations can be specified in the `@EnableFeignClients` attribute `defaultConfiguration` in a similar manner as described above. The difference is that this configuration will apply to _all_ feign clients.


### PR DESCRIPTION
document requirements for decoders (+ others) specified via class in the config
These requirements arise from the behavior of `FeignClientFactoryBean.getOrInstantiate`.

At the moment it's unclear what restrictions the frameworks imposes on them.