### PR TITLE
(fix): Incorrect resolved url when the FeignClient.path is set and the base url is defined in the properties file

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/DefaultTargeter.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/DefaultTargeter.java
@@ -26,7 +26,7 @@ class DefaultTargeter implements Targeter {
 
 	@Override
 	public <T> T target(FeignClientFactoryBean factory, Feign.Builder feign, FeignClientFactory context,
-			Target.HardCodedTarget<T> target) {
+			Target<T> target) {
 		return feign.target(target);
 	}
 

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignCircuitBreakerTargeter.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignCircuitBreakerTargeter.java
@@ -44,7 +44,7 @@ class FeignCircuitBreakerTargeter implements Targeter {
 
 	@Override
 	public <T> T target(FeignClientFactoryBean factory, Feign.Builder feign, FeignClientFactory context,
-			Target.HardCodedTarget<T> target) {
+			Target<T> target) {
 		if (!(feign instanceof FeignCircuitBreaker.Builder builder)) {
 			return feign.target(target);
 		}
@@ -61,14 +61,14 @@ class FeignCircuitBreakerTargeter implements Targeter {
 	}
 
 	private <T> T targetWithFallbackFactory(String feignClientName, FeignClientFactory context,
-			Target.HardCodedTarget<T> target, FeignCircuitBreaker.Builder builder, Class<?> fallbackFactoryClass) {
+			Target<T> target, FeignCircuitBreaker.Builder builder, Class<?> fallbackFactoryClass) {
 		FallbackFactory<? extends T> fallbackFactory = (FallbackFactory<? extends T>) getFromContext("fallbackFactory",
 				feignClientName, context, fallbackFactoryClass, FallbackFactory.class);
 		return builder(feignClientName, builder).target(target, fallbackFactory);
 	}
 
 	private <T> T targetWithFallback(String feignClientName, FeignClientFactory context,
-			Target.HardCodedTarget<T> target, FeignCircuitBreaker.Builder builder, Class<?> fallback) {
+			Target<T> target, FeignCircuitBreaker.Builder builder, Class<?> fallback) {
 		T fallbackInstance = getFromContext("fallback", feignClientName, context, fallback, target.type());
 		return builder(feignClientName, builder).target(target, fallbackInstance);
 	}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/PathPrefixedTarget.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/PathPrefixedTarget.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2013-2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign;
+
+import feign.Request;
+import feign.RequestTemplate;
+import feign.Target;
+
+class PathPrefixedTarget<T> implements Target<T> {
+	private final String path;
+	private final Target<T> target;
+
+	PathPrefixedTarget(String path, Target<T> target) {
+		this.path = path;
+		this.target = target;
+	}
+
+	@Override
+	public Class<T> type() {
+		return this.target.type();
+	}
+
+	@Override
+	public String name() {
+		return this.target.name();
+	}
+
+	@Override
+	public String url() {
+		return this.target.url() + this.path;
+	}
+
+	@Override
+	public Request apply(RequestTemplate input) {
+		RequestTemplate template = input.target(this.url());
+		return this.target.apply(template);
+	}
+}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/Targeter.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/Targeter.java
@@ -25,6 +25,6 @@ import feign.Target;
 public interface Targeter {
 
 	<T> T target(FeignClientFactoryBean factory, Feign.Builder feign, FeignClientFactory context,
-			Target.HardCodedTarget<T> target);
+			Target<T> target);
 
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlTests.java
@@ -154,7 +154,7 @@ class FeignHttpClientUrlTests {
 			return new Targeter() {
 				@Override
 				public <T> T target(FeignClientFactoryBean factory, Feign.Builder feign, FeignClientFactory context,
-						Target.HardCodedTarget<T> target) {
+						Target<T> target) {
 					Field field = ReflectionUtils.findField(Feign.Builder.class, "client");
 					ReflectionUtils.makeAccessible(field);
 					Client client = (Client) ReflectionUtils.getField(field, feign);

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlWithRetryableLoadBalancerTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlWithRetryableLoadBalancerTests.java
@@ -155,7 +155,7 @@ class FeignHttpClientUrlWithRetryableLoadBalancerTests {
 			return new Targeter() {
 				@Override
 				public <T> T target(FeignClientFactoryBean factory, Feign.Builder feign, FeignClientFactory context,
-						Target.HardCodedTarget<T> target) {
+						Target<T> target) {
 					Field field = ReflectionUtils.findField(Feign.Builder.class, "client");
 					ReflectionUtils.makeAccessible(field);
 					Client client = (Client) ReflectionUtils.getField(field, feign);

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/NonRefreshableFeignClientUrlTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/NonRefreshableFeignClientUrlTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.openfeign;
 
-import feign.Target;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -53,7 +52,6 @@ class NonRefreshableFeignClientUrlTests {
 	void shouldInstantiateFeignClientWhenUrlFromFeignClientUrl() {
 		UrlTestClient.UrlResponseForTests response = feignClientWithFixUrl.fixPath();
 		assertThat(response.getUrl()).isEqualTo("http://localhost:8081/fixPath");
-		assertThat(response.getTargetType()).isEqualTo(Target.HardCodedTarget.class);
 	}
 
 	@Test
@@ -66,14 +64,12 @@ class NonRefreshableFeignClientUrlTests {
 	public void shouldInstantiateFeignClientWhenUrlFromProperties() {
 		UrlTestClient.UrlResponseForTests response = configBasedClient.test();
 		assertThat(response.getUrl()).isEqualTo("http://localhost:9999/test");
-		assertThat(response.getTargetType()).isEqualTo(PropertyBasedTarget.class);
 	}
 
 	@Test
 	void shouldInstantiateFeignClientWhenUrlFromFeignClientName() {
 		UrlTestClient.UrlResponseForTests response = nameBasedUrlClient.test();
 		assertThat(response.getUrl()).isEqualTo("http://nameBasedClient/test");
-		assertThat(response.getTargetType()).isEqualTo(Target.HardCodedTarget.class);
 	}
 
 	@Test
@@ -82,7 +78,6 @@ class NonRefreshableFeignClientUrlTests {
 	) {
 		UrlTestClient.UrlResponseForTests response = withPathAndFixUrlClient.test();
 		assertThat(response.getUrl()).isEqualTo("http://localhost:7777/common/test");
-		assertThat(response.getTargetType()).isEqualTo(Target.HardCodedTarget.class);
 	}
 
 	@Test
@@ -91,7 +86,6 @@ class NonRefreshableFeignClientUrlTests {
 	) {
 		UrlTestClient.UrlResponseForTests response = withPathAndUrlFromConfigClient.test();
 		assertThat(response.getUrl()).isEqualTo("http://localhost:7777/common/test");
-		assertThat(response.getTargetType()).isEqualTo(Target.HardCodedTarget.class);
 	}
 
 	@Configuration

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/NonRefreshableFeignClientUrlTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/NonRefreshableFeignClientUrlTests.java
@@ -76,11 +76,36 @@ class NonRefreshableFeignClientUrlTests {
 		assertThat(response.getTargetType()).isEqualTo(Target.HardCodedTarget.class);
 	}
 
+	@Test
+	void shouldInstantiateFeignClientWhenUrlAndPathAreInTheFeignClientAnnotation(
+		@Autowired Application.WithPathAndFixUrlClient withPathAndFixUrlClient
+	) {
+		UrlTestClient.UrlResponseForTests response = withPathAndFixUrlClient.test();
+		assertThat(response.getUrl()).isEqualTo("http://localhost:7777/common/test");
+		assertThat(response.getTargetType()).isEqualTo(Target.HardCodedTarget.class);
+	}
+
+	@Test
+	void shouldInstantiateFeignClientWhenUrlFromPropertiesAndPathInTheFeignClientAnnotation(
+		@Autowired Application.WithPathAndUrlFromConfigClient withPathAndUrlFromConfigClient
+	) {
+		UrlTestClient.UrlResponseForTests response = withPathAndUrlFromConfigClient.test();
+		assertThat(response.getUrl()).isEqualTo("http://localhost:7777/common/test");
+		assertThat(response.getTargetType()).isEqualTo(Target.HardCodedTarget.class);
+	}
+
 	@Configuration
 	@EnableAutoConfiguration
 	@EnableConfigurationProperties(FeignClientProperties.class)
-	@EnableFeignClients(clients = { Application.FeignClientWithFixUrl.class, Application.ConfigBasedClient.class,
-			Application.NameBasedUrlClient.class })
+	@EnableFeignClients(
+		clients = {
+			Application.FeignClientWithFixUrl.class,
+			Application.ConfigBasedClient.class,
+			Application.NameBasedUrlClient.class,
+			Application.WithPathAndUrlFromConfigClient.class,
+			Application.WithPathAndFixUrlClient.class
+		}
+	)
 	protected static class Application {
 
 		@Bean
@@ -106,6 +131,22 @@ class NonRefreshableFeignClientUrlTests {
 
 		@FeignClient(name = "nameBasedClient")
 		protected interface NameBasedUrlClient {
+
+			@GetMapping("/test")
+			UrlTestClient.UrlResponseForTests test();
+
+		}
+
+		@FeignClient(name = "withPathAndFixUrlClient", path = "/common", url = "http://localhost:7777")
+		protected interface WithPathAndFixUrlClient {
+
+			@GetMapping("/test")
+			UrlTestClient.UrlResponseForTests test();
+
+		}
+
+		@FeignClient(name = "withPathAndUrlFromConfigClient", path = "/common")
+		protected interface WithPathAndUrlFromConfigClient {
 
 			@GetMapping("/test")
 			UrlTestClient.UrlResponseForTests test();

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/PathPrefixedTargetTest.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/PathPrefixedTargetTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign;
+
+import feign.RequestTemplate;
+import feign.Target;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@ExtendWith(MockitoExtension.class)
+class PathPrefixedTargetTest {
+	private final String url = "http://localhost:8080";
+	private final Target<?> target;
+
+	PathPrefixedTargetTest(@Mock Target<?> target) {
+		this.target = target;
+	}
+
+	@BeforeEach
+	void setUp() {
+		when(this.target.url()).thenReturn(this.url);
+	}
+
+	@Test
+	void urlAndPathAreConcatenated() {
+		String path = "/common";
+		PathPrefixedTarget<?> pathPrefixedTarget = new PathPrefixedTarget<>(path, this.target);
+
+		assertThat(pathPrefixedTarget.url()).isEqualTo(this.url + path);
+	}
+
+	@Test
+	void concatenatedUrlIsPassedIntoRequestTemplate(@Mock RequestTemplate template) {
+		String path = "/common";
+		PathPrefixedTarget<?> pathPrefixedTarget = new PathPrefixedTarget<>(path, this.target);
+
+		pathPrefixedTarget.apply(template);
+
+		verify(template).target(pathPrefixedTarget.url());
+	}
+}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/RefreshableFeignClientUrlTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/RefreshableFeignClientUrlTests.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cloud.openfeign;
 
-import feign.Target;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -66,7 +65,6 @@ class RefreshableFeignClientUrlTests {
 	void shouldInstantiateFeignClientWhenUrlFromFeignClientUrl() {
 		UrlTestClient.UrlResponseForTests response = refreshableClientWithFixUrl.fixPath();
 		assertThat(response.getUrl()).isEqualTo("http://localhost:8081/fixPath");
-		assertThat(response.getTargetType()).isEqualTo(Target.HardCodedTarget.class);
 	}
 
 	@Test
@@ -79,7 +77,6 @@ class RefreshableFeignClientUrlTests {
 	public void shouldInstantiateFeignClientWhenUrlFromProperties() {
 		UrlTestClient.UrlResponseForTests response = refreshableUrlClient.refreshable();
 		assertThat(response.getUrl()).isEqualTo("http://localhost:8082/refreshable");
-		assertThat(response.getTargetType()).isEqualTo(RefreshableHardCodedTarget.class);
 	}
 
 	@Test
@@ -97,7 +94,6 @@ class RefreshableFeignClientUrlTests {
 	void shouldInstantiateFeignClientWhenUrlFromFeignClientName() {
 		UrlTestClient.UrlResponseForTests response = nameBasedUrlClient.nonRefreshable();
 		assertThat(response.getUrl()).isEqualTo("http://nameBasedClient/nonRefreshable");
-		assertThat(response.getTargetType()).isEqualTo(Target.HardCodedTarget.class);
 	}
 
 	@Configuration

--- a/spring-cloud-openfeign-core/src/test/resources/feign-properties.properties
+++ b/spring-cloud-openfeign-core/src/test/resources/feign-properties.properties
@@ -28,3 +28,4 @@ spring.cloud.openfeign.client.config.connectTimeout.connectTimeout=1000
 spring.cloud.openfeign.client.config.default.followRedirects=false
 spring.cloud.openfeign.client.config.feignClientWithFixUrl.url=http://localhost:8888
 spring.cloud.openfeign.client.config.configBasedClient.url=http://localhost:9999
+spring.cloud.openfeign.client.config.withPathAndUrlFromConfigClient.url=http://localhost:7777


### PR DESCRIPTION
Main changes:
1. Decorate a target with new `PathPrefixedTarget` target that adds path to the url.
2. Change `Targeter.target`'s signature: Target.HardcodedTarget -> Target
3. Cleanup tests from things which should not be checked

Closes https://github.com/spring-cloud/spring-cloud-openfeign/issues/923, https://github.com/spring-cloud/spring-cloud-openfeign/pull/924