### PR TITLE
Improve RequestParam annotation parameter processor logic

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/RequestParamParameterProcessor.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/RequestParamParameterProcessor.java
@@ -58,8 +58,7 @@ public class RequestParamParameterProcessor implements AnnotatedParameterProcess
 			return true;
 		}
 
-		RequestParam requestParam = ANNOTATION.cast(annotation);
-		String name = requestParam.value();
+		String name = ANNOTATION.cast(annotation).value();
 		checkState(emptyToNull(name) != null, "RequestParam.value() was empty on parameter %s of method %s",
 				parameterIndex, method.getName());
 		context.setParameterName(name);


### PR DESCRIPTION
## Description

If the logic in the `processArgument` method does not appear in a specific `annotation class`, I will be able to directly reuse the original logic to encapsulate custom annotations.

```
public class RpcHeaderParameterProcessor extends RequestHeaderParameterProcessor {

    private static final Class<RpcHeader> ANNOTATION = RpcHeader.class;

    @Override
    public Class<? extends Annotation> getAnnotationType() {
        return ANNOTATION;
    }

    @Override
    public boolean processArgument(AnnotatedParameterContext context, Annotation annotation, Method method) {
        // DO SOMETHING
        return super.processArgument(context, annotation, method);
    }

}

```

## Similar Code

https://github.com/spring-cloud/spring-cloud-openfeign/blob/bd560f1fffee2beee6f1496f4522dceb340108fb/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/RequestHeaderParameterProcessor.java#L61
