### PR TITLE
SpringMvcContract support parse params

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-openfeign.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-openfeign.adoc
@@ -701,6 +701,36 @@ public interface DemoClient {
 
 You can also disable the feature via property `spring.cloud.openfeign.cache.enabled=false`.
 
+
+[[spring-requestmapping-support]]
+=== Spring @RequestMapping Support
+
+Spring Cloud OpenFeign provides support for the Spring `@RequestMapping` annotation and its derived annotations (such as `@GetMapping`, `@PostMapping`, etc.) support.
+The attributes on the `@RequestMapping` annotation (including `value`, `method`, `params`, `headers`, `consumes`, and `produces`) will be parsed by `SpringMvcContract` as the content of the request.
+
+
+For example:
+
+Define an interface using the `params` attribute.
+
+[source,java,indent=0]
+----
+@FeignClient("demo")
+public interface DemoTemplate {
+
+        @PostMapping(value = "/stores/{storeId}", params = "mode=upsert")
+        Store update(@PathVariable("storeId") Long storeId, Store store);
+}
+----
+
+In the above example, the request url will be resolved to `/stores/{storeId}?mode=upsert`. +
+The params attribute also supports the use of multiple `key=value` or only one `key`. For example: +
+
+- When `params = { "key1=v1", "key2=v2" }`, the request url will be parsed as `/stores/{storeId}?key1=v1&key2=v2`.
+- When `params = "key"`, the request url will be parsed as `/stores/{storeId}?key`.
+
+
+
 [[feign-querymap-support]]
 === Feign @QueryMap support
 

--- a/docs/modules/ROOT/pages/spring-cloud-openfeign.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-openfeign.adoc
@@ -705,11 +705,11 @@ You can also disable the feature via property `spring.cloud.openfeign.cache.enab
 [[spring-requestmapping-support]]
 === Spring @RequestMapping Support
 
-Spring Cloud OpenFeign provides support for the Spring `@RequestMapping` annotation and its derived annotations (such as `@GetMapping`, `@PostMapping`, etc.) support.
-The attributes on the `@RequestMapping` annotation (including `value`, `method`, `params`, `headers`, `consumes`, and `produces`) will be parsed by `SpringMvcContract` as the content of the request.
+Spring Cloud OpenFeign provides support for the Spring `@RequestMapping` annotation and its derived annotations (such as `@GetMapping`, `@PostMapping`, and others) support.
+The attributes on the `@RequestMapping` annotation (including `value`, `method`, `params`, `headers`, `consumes`, and `produces`) are parsed by `SpringMvcContract` as the content of the request.
 
 
-For example:
+Consider the following example:
 
 Define an interface using the `params` attribute.
 
@@ -723,11 +723,11 @@ public interface DemoTemplate {
 }
 ----
 
-In the above example, the request url will be resolved to `/stores/{storeId}?mode=upsert`. +
-The params attribute also supports the use of multiple `key=value` or only one `key`. For example: +
+In the above example, the request url is resolved to `/stores/{storeId}?mode=upsert`. +
+The params attribute also supports the use of multiple `key=value` or only one `key`: +
 
-- When `params = { "key1=v1", "key2=v2" }`, the request url will be parsed as `/stores/{storeId}?key1=v1&key2=v2`.
-- When `params = "key"`, the request url will be parsed as `/stores/{storeId}?key`.
+- When `params = { "key1=v1", "key2=v2" }`, the request url is parsed as `/stores/{storeId}?key1=v1&key2=v2`.
+- When `params = "key"`, the request url is parsed as `/stores/{storeId}?key`.
 
 
 

--- a/docs/modules/ROOT/pages/spring-cloud-openfeign.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-openfeign.adoc
@@ -45,7 +45,7 @@ public interface StoreClient {
 	@GetMapping("/stores")
 	Page<Store> getStores(Pageable pageable);
 
-	@PostMapping(value = "/stores/{storeId}", consumes = "application/json")
+	@PostMapping(value = "/stores/{storeId}", consumes = "application/json", params = "mode=upsert")
 	Store update(@PathVariable("storeId") Long storeId, Store store);
 
 	@DeleteMapping("/stores/{storeId:\\d+}")

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -87,6 +87,7 @@ import static org.springframework.core.annotation.AnnotatedElementUtils.findMerg
  * @author Darren Foong
  * @author Ram Anaswara
  * @author Sam Kruglov
+ * @author Tang Xiong
  */
 public class SpringMvcContract extends Contract.BaseContract implements ResourceLoaderAware {
 
@@ -244,6 +245,9 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 		// headers
 		parseHeaders(data, method, methodMapping);
 
+		// params
+		parseParams(data, method, methodMapping);
+
 		data.indexToExpander(new LinkedHashMap<>());
 	}
 
@@ -350,6 +354,19 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 					md.template().header(resolve(header.substring(0, index)),
 							resolve(header.substring(index + 1).trim()));
 				}
+			}
+		}
+	}
+
+	private void parseParams(MethodMetadata data, Method method, RequestMapping methodMapping) {
+		String[] params = methodMapping.params();
+		if (params == null || params.length == 0) {
+			return;
+		}
+		for (String param : params) {
+			NameValueResolver nameValueResolver = new NameValueResolver(param);
+			if (!nameValueResolver.isNegated()) {
+				data.template().query(resolve(nameValueResolver.getName()), resolve(nameValueResolver.getValue()));
 			}
 		}
 	}
@@ -461,6 +478,43 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 		@Override
 		public Collection<String> setTemplateParameter(String name, Collection<String> rest) {
 			return addTemplateParameter(rest, name);
+		}
+
+	}
+
+	private static class NameValueResolver {
+
+		private final String name;
+
+		private final String value;
+
+		private final boolean isNegated;
+
+		NameValueResolver(String expression) {
+			int separator = expression.indexOf('=');
+			if (separator == -1) {
+				this.isNegated = expression.startsWith("!");
+				this.name = (this.isNegated ? expression.substring(1) : expression);
+				this.value = null;
+			}
+			else {
+				this.isNegated = (separator > 0) && (expression.charAt(separator - 1) == '!');
+				this.name = (this.isNegated ? expression.substring(0, separator - 1)
+						: expression.substring(0, separator));
+				this.value = expression.substring(separator + 1);
+			}
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public String getValue() {
+			return value;
+		}
+
+		public boolean isNegated() {
+			return isNegated;
 		}
 
 	}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -368,6 +368,9 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 			if (!nameValueResolver.isNegated()) {
 				data.template().query(resolve(nameValueResolver.getName()), resolve(nameValueResolver.getValue()));
 			}
+			else {
+				throw new IllegalArgumentException("Negated params are not supported: " + param);
+			}
 		}
 	}
 
@@ -493,15 +496,14 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 		NameValueResolver(String expression) {
 			int separator = expression.indexOf('=');
 			if (separator == -1) {
-				this.isNegated = expression.startsWith("!");
-				this.name = (this.isNegated ? expression.substring(1) : expression);
-				this.value = null;
+				isNegated = expression.startsWith("!");
+				name = (isNegated ? expression.substring(1) : expression);
+				value = null;
 			}
 			else {
-				this.isNegated = (separator > 0) && (expression.charAt(separator - 1) == '!');
-				this.name = (this.isNegated ? expression.substring(0, separator - 1)
-						: expression.substring(0, separator));
-				this.value = expression.substring(separator + 1);
+				isNegated = (separator > 0) && (expression.charAt(separator - 1) == '!');
+				name = (isNegated ? expression.substring(0, separator - 1) : expression.substring(0, separator));
+				value = expression.substring(separator + 1);
 			}
 		}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
@@ -510,10 +510,18 @@ class SpringMvcContractTests {
 
 	@Test
 	void testProcessAnnotations_ParseParams_NotEqualParams() throws Exception {
-		Method method = TestTemplate_ParseParams.class.getDeclaredMethod("notEqualParams");
+		assertThatIllegalArgumentException().isThrownBy(() -> {
+			Method method = TestTemplate_ParseParams.class.getDeclaredMethod("notEqualParams");
+			contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+		});
+	}
+
+	@Test
+	void testProcessAnnotations_ParseParams_ParamsAndRequestParam() throws Exception {
+		Method method = TestTemplate_ParseParams.class.getDeclaredMethod("paramsAndRequestParam", String.class);
 		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
 
-		assertThat(data.template().url()).isEqualTo("/test");
+		assertThat(data.template().url()).isEqualTo("/test?p1=1&p2={p2}");
 		assertThat(data.template().method()).isEqualTo("GET");
 	}
 
@@ -824,6 +832,9 @@ class SpringMvcContractTests {
 
 		@GetMapping(value = "test", params = { "p1!=1" })
 		ResponseEntity<TestObject> notEqualParams();
+
+		@GetMapping(value = "test", params = { "p1=1" })
+		ResponseEntity<TestObject> paramsAndRequestParam(@RequestParam("p2") String p2);
 
 	}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2023 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -82,6 +82,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * @author Szymon Linowski
  * @author Sam Kruglov
  * @author Bhavya Agrawal
+ * @author Tang Xiong
  **/
 
 class SpringMvcContractTests {
@@ -463,6 +464,60 @@ class SpringMvcContractTests {
 	}
 
 	@Test
+	void testProcessAnnotations_ParseParams_SingleParam() throws Exception {
+		Method method = TestTemplate_ParseParams.class.getDeclaredMethod("singleParam");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/test?p1=1");
+		assertThat(data.template().method()).isEqualTo("GET");
+	}
+
+	@Test
+	void testProcessAnnotations_ParseParams_MultipleParams() throws Exception {
+		Method method = TestTemplate_ParseParams.class.getDeclaredMethod("multipleParams");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/test?p1=1&p2=2");
+		assertThat(data.template().method()).isEqualTo("GET");
+	}
+
+	@Test
+	void testProcessAnnotations_ParseParams_MixParams() throws Exception {
+		Method method = TestTemplate_ParseParams.class.getDeclaredMethod("mixParams");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/test?p1=1&p2");
+		assertThat(data.template().method()).isEqualTo("GET");
+	}
+
+	@Test
+	void testProcessAnnotations_ParseParams_SingleParamWithoutValue() throws Exception {
+		Method method = TestTemplate_ParseParams.class.getDeclaredMethod("singleParamWithoutValue");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/test?p1");
+		assertThat(data.template().method()).isEqualTo("GET");
+	}
+
+	@Test
+	void testProcessAnnotations_ParseParams_MultipleParamsWithoutValue() throws Exception {
+		Method method = TestTemplate_ParseParams.class.getDeclaredMethod("multipleParamsWithoutValue");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/test?p1&p2");
+		assertThat(data.template().method()).isEqualTo("GET");
+	}
+
+	@Test
+	void testProcessAnnotations_ParseParams_NotEqualParams() throws Exception {
+		Method method = TestTemplate_ParseParams.class.getDeclaredMethod("notEqualParams");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/test");
+		assertThat(data.template().method()).isEqualTo("GET");
+	}
+
+	@Test
 	void testProcessHeaders() throws Exception {
 		Method method = TestTemplate_Headers.class.getDeclaredMethod("getTest", String.class);
 		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
@@ -747,6 +802,28 @@ class SpringMvcContractTests {
 
 		@GetMapping("/test")
 		ResponseEntity<TestObject> getTest(@RequestParam Map<String, String> params);
+
+	}
+
+	public interface TestTemplate_ParseParams {
+
+		@GetMapping(value = "test", params = "p1=1")
+		ResponseEntity<TestObject> singleParam();
+
+		@GetMapping(value = "test", params = { "p1=1", "p2=2" })
+		ResponseEntity<TestObject> multipleParams();
+
+		@GetMapping(value = "test", params = { "p1" })
+		ResponseEntity<TestObject> singleParamWithoutValue();
+
+		@GetMapping(value = "test", params = { "p1", "p2" })
+		ResponseEntity<TestObject> multipleParamsWithoutValue();
+
+		@GetMapping(value = "test", params = { "p1=1", "p2" })
+		ResponseEntity<TestObject> mixParams();
+
+		@GetMapping(value = "test", params = { "p1!=1" })
+		ResponseEntity<TestObject> notEqualParams();
 
 	}
 


### PR DESCRIPTION
Previously, SpringMvcContract did not support parsing the `params` parameter of `@RequestMapping`.

Example:

1. Define a rest interface that uses the `params` parameter：
```
@PutMapping(value = "/user", params = "action=disable")
public String disableUser() {
    return "user";
}
```
2. Define a FeignClient to call the previously declared interface：

```
@FeignClient("user-server")
static interface UserService {
    @PutMapping(value = "/user", params = "action=disable")
    String disableUser();
}
```

When sending this request, the request path will be resolved to `/user` instead of `/user?action=disable`, resulting in 400 errors.
Therefore, this PR provides the ability to parse `params` parameter.
