### PR TITLE
Ignore unresolved property placeholders in `url`

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
@@ -80,6 +80,14 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 	FeignClientsRegistrar() {
 	}
 
+	private static boolean isSpEL(String value) {
+		return value.startsWith("#{") && value.contains("}");
+	}
+
+	private static boolean isPlaceholder(String value) {
+		return value.startsWith("${") && value.endsWith("}");
+	}
+
 	static void validateFallback(final Class clazz) {
 		Assert.isTrue(!clazz.isInterface(), "Fallback class must implement the interface annotated by @FeignClient");
 	}
@@ -113,7 +121,7 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 	}
 
 	static String getUrl(String url) {
-		if (StringUtils.hasText(url) && !(url.startsWith("#{") && url.contains("}"))) {
+		if (StringUtils.hasText(url) && !isSpEL(url) && !isPlaceholder(url)) {
 			if (!url.contains("://")) {
 				url = "http://" + url;
 			}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
@@ -67,6 +67,7 @@ import org.springframework.util.StringUtils;
  * @author Marcin Grzejszczak
  * @author Olga Maciaszek-Sharma
  * @author Jasbir Singh
+ * @author Elkhan Eminov
  */
 class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLoaderAware, EnvironmentAware {
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientsRegistrarTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientsRegistrarTests.java
@@ -42,6 +42,7 @@ import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
  * @author Michal Domagala
  * @author Szymon Linowski
  * @author Olga Maciaszek-Sharma
+ * @author Elkhan Eminov
  */
 class FeignClientsRegistrarTests {
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientsRegistrarTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientsRegistrarTests.java
@@ -83,6 +83,13 @@ class FeignClientsRegistrarTests {
 		assertThat(name).as("name was wrong").isEqualTo("https://goodname");
 	}
 
+	@Test
+	void goodUrlPlaceholder() {
+		String urlPlaceholder = "${url.property}";
+		String url = FeignClientsRegistrar.getUrl(urlPlaceholder);
+		assertThat(url).as("url was wrong").isEqualTo(urlPlaceholder);
+	}
+
 	private String testGetName(String name) {
 		FeignClientsRegistrar registrar = new FeignClientsRegistrar();
 		registrar.setEnvironment(new MockEnvironment());

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlTests.java
@@ -47,6 +47,7 @@ import static org.springframework.cloud.openfeign.FeignHttpClientUrlTests.URL_PR
 /**
  * @author Spencer Gibb
  * @author Olga Maciaszek-Sharma
+ * @author Elkhan Eminov
  */
 @SpringBootTest(classes = FeignHttpClientUrlTests.TestConfig.class, webEnvironment = DEFINED_PORT,
 		value = {"spring.application.name=feignclienturltest", "spring.cloud.openfeign.circuitbreaker.enabled=false",

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlWithRetryableLoadBalancerTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlWithRetryableLoadBalancerTests.java
@@ -48,6 +48,7 @@ import static org.springframework.cloud.openfeign.FeignHttpClientUrlWithRetryabl
 /**
  * @author Spencer Gibb
  * @author Olga Maciaszek-Sharma
+ * @author Elkhan Eminov
  */
 @SpringBootTest(classes = FeignHttpClientUrlWithRetryableLoadBalancerTests.TestConfig.class,
 		webEnvironment = DEFINED_PORT,

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlWithRetryableLoadBalancerTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignHttpClientUrlWithRetryableLoadBalancerTests.java
@@ -42,6 +42,8 @@ import org.springframework.web.bind.annotation.RestController;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.DEFINED_PORT;
+import static org.springframework.cloud.openfeign.FeignHttpClientUrlWithRetryableLoadBalancerTests.NO_PROTOCOL_URL_PROPERTY_KEY;
+import static org.springframework.cloud.openfeign.FeignHttpClientUrlWithRetryableLoadBalancerTests.URL_PROPERTY_KEY;
 
 /**
  * @author Spencer Gibb
@@ -50,9 +52,14 @@ import static org.springframework.boot.test.context.SpringBootTest.WebEnvironmen
 @SpringBootTest(classes = FeignHttpClientUrlWithRetryableLoadBalancerTests.TestConfig.class,
 		webEnvironment = DEFINED_PORT,
 		value = { "spring.application.name=feignclienturlwithretryableloadbalancertest",
-				"spring.cloud.openfeign.hystrix.enabled=false", "spring.cloud.openfeign.okhttp.enabled=false" })
+				  "spring.cloud.openfeign.hystrix.enabled=false", "spring.cloud.openfeign.okhttp.enabled=false",
+				  URL_PROPERTY_KEY + "=http://localhost:${server.port}/",
+				  NO_PROTOCOL_URL_PROPERTY_KEY + "=localhost:${server.port}/"})
 @DirtiesContext
 class FeignHttpClientUrlWithRetryableLoadBalancerTests {
+
+	static final String URL_PROPERTY_KEY = "url.property";
+	static final String NO_PROTOCOL_URL_PROPERTY_KEY = "noprotocol.url.property";
 
 	static int port;
 
@@ -64,6 +71,12 @@ class FeignHttpClientUrlWithRetryableLoadBalancerTests {
 
 	@Autowired
 	private BeanUrlClient beanClient;
+
+	@Autowired
+	private PropertyUrlClient propertyUrlClient;
+
+	@Autowired
+	private NoProtocolPropertyUrlClient noProtocolPropertyUrlClient;
 
 	@BeforeAll
 	static void beforeClass() {
@@ -98,6 +111,20 @@ class FeignHttpClientUrlWithRetryableLoadBalancerTests {
 		assertThat(hello).as("first hello didn't match").isEqualTo(new Hello("hello world 1"));
 	}
 
+	@Test
+	void testPropertyUrl() {
+		Hello hello = propertyUrlClient.getHello();
+		assertThat(hello).as("hello was null").isNotNull();
+		assertThat(hello).as("first hello didn't match").isEqualTo(new Hello("hello world 1"));
+	}
+
+	@Test
+	void testNoProtocolPropertyUrl() {
+		Hello hello = noProtocolPropertyUrlClient.getHello();
+		assertThat(hello).as("hello was null").isNotNull();
+		assertThat(hello).as("first hello didn't match").isEqualTo(new Hello("hello world 1"));
+	}
+
 	// this tests that
 	@FeignClient(name = "localappurl", url = "http://localhost:${server.port}/")
 	protected interface UrlClient {
@@ -123,10 +150,30 @@ class FeignHttpClientUrlWithRetryableLoadBalancerTests {
 
 	}
 
+	@FeignClient(name = "propertyurl", url = "${" + URL_PROPERTY_KEY + "}")
+	protected interface PropertyUrlClient {
+
+		@GetMapping("/hello")
+		Hello getHello();
+	}
+
+	@FeignClient(name = "propertyurlnoprotocol", url = "${" + NO_PROTOCOL_URL_PROPERTY_KEY + "}")
+	protected interface NoProtocolPropertyUrlClient {
+
+		@GetMapping("/hello")
+		Hello getHello();
+	}
+
 	@Configuration(proxyBeanMethods = false)
 	@EnableAutoConfiguration
 	@RestController
-	@EnableFeignClients(clients = { UrlClient.class, BeanUrlClient.class, BeanUrlClientNoProtocol.class })
+	@EnableFeignClients(clients = {
+		UrlClient.class,
+		BeanUrlClient.class,
+		BeanUrlClientNoProtocol.class,
+		PropertyUrlClient.class,
+		NoProtocolPropertyUrlClient.class
+	})
 	@Import(NoSecurityConfiguration.class)
 	protected static class TestConfig {
 


### PR DESCRIPTION
fixes https://github.com/spring-cloud/spring-cloud-openfeign/issues/1023

`FeignClientRegistar` seems to [purposefully ignore](https://github.com/spring-cloud/spring-cloud-openfeign/blob/ca4de4e703a953504c3bb7b08fa8c69566697953/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java#L116) unresolved URLs that are SpEL but doesn't do so for property placeholders like `${placeholder}`.
For ignored SpEL strings, the input string is returned, but for placeholders, it tries to [parse it into a `URL` object](https://github.com/spring-cloud/spring-cloud-openfeign/blob/ca4de4e703a953504c3bb7b08fa8c69566697953/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java#L121).
Up until JDK 20, this would be OK and would not fail - and unresolved placeholder URL would probably fail somewhere later down the flow. This is because the underlying implementation of the `URL` class doesn't actually try to parse the host until unless the `URL.openConnection()` is called, which is not called in this method.

[Since JDK 20](https://bugs.openjdk.org/browse/JDK-8293590), this behaviour has changed and the underlying implementation of the `URL` class now parses the host eagerly without waiting for a `URL.openConnection()` call.

This was discovered when our tests that use [@JsonTest](https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/json/JsonTest.html) started failing once we upgraded to JDK 20+