### PR TITLE
Update additional-spring-configuration-metadata.json

### DIFF
--- a/spring-cloud-openfeign-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-openfeign-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -27,12 +27,6 @@
 			"defaultValue": "false"
 		},
 		{
-			"name": "spring.cloud.openfeign.httpclient.enabled",
-			"type": "java.lang.Boolean",
-			"description": "Enables the use of the Apache HTTP Client by Feign.",
-			"defaultValue": "true"
-		},
-		{
 			"name": "spring.cloud.openfeign.httpclient.hc5.enabled",
 			"type": "java.lang.Boolean",
 			"description": "Enables the use of the Apache HTTP Client 5 by Feign.",


### PR DESCRIPTION
Starting with Spring Cloud OpenFeign 4, the Feign Apache HttpClient 4 is no longer supported