### PR TITLE
fix: defaultValue in additional-spring-configuration-metadata.json

### DIFF
--- a/spring-cloud-openfeign-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/spring-cloud-openfeign-core/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -24,7 +24,7 @@
 			"name": "spring.cloud.openfeign.circuitbreaker.alphanumeric-ids.enabled",
 			"type": "java.lang.Boolean",
 			"description": "If true, Circuit Breaker ids will only contain alphanumeric characters to allow for configuration via configuration properties.",
-			"defaultValue": "false"
+			"defaultValue": "true"
 		},
 		{
 			"name": "spring.cloud.openfeign.httpclient.hc5.enabled",


### PR DESCRIPTION
defaultValue of `spring.cloud.openfeign.circuitbreaker.alphanumeric-ids.enabled` is `true` since version 4.0.0