### PR TITLE
fix #1102: feign-form-spring relocated under io.github.openfeign

### DIFF
--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -91,23 +91,15 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>io.github.openfeign.form</groupId>
+			<groupId>io.github.openfeign</groupId>
 			<artifactId>feign-form-spring</artifactId>
 			<exclusions>
-<!--				Vulnerable in 3.8.0-->
+<!--				Still vulnerable in 13.5-->
 				<exclusion>
 					<groupId>commons-io</groupId>
 					<artifactId>commons-io</artifactId>
 				</exclusion>
-				<exclusion>
-					<groupId>commons-fileupload</groupId>
-					<artifactId>commons-fileupload</artifactId>
-				</exclusion>
 			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.github.openfeign</groupId>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -16,7 +16,6 @@
 	<description>Spring Cloud OpenFeign Dependencies</description>
 	<properties>
 		<feign.version>13.5</feign.version>
-		<feign-form.version>3.8.0</feign-form.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -36,22 +35,6 @@
 				<version>${feign.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>io.github.openfeign.form</groupId>
-				<artifactId>feign-form-spring</artifactId>
-				<version>${feign-form.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>commons-fileupload</groupId>
-						<artifactId>commons-fileupload</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>commons-fileupload</groupId>
-				<artifactId>commons-fileupload</artifactId>
-				<version>1.5</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Leaving the exclusion for `commons-io` for now since it still has vulnerabilities in versions < 2.14 (See also #1098), which is still a transitive dependency of [`feign-form-spring:13.5`](https://mvnrepository.com/artifact/io.github.openfeign/feign-form-spring/13.5) (via [`commons-fileupload:1.5`](https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload/1.5)).