### PR TITLE
fix #1102: feign-form-spring relocated under io.github.openfeign (backport #1103)

### DIFF
--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -91,23 +91,8 @@
 			<optional>true</optional>
 		</dependency>
 		<dependency>
-			<groupId>io.github.openfeign.form</groupId>
+			<groupId>io.github.openfeign</groupId>
 			<artifactId>feign-form-spring</artifactId>
-			<exclusions>
-<!--				Vulnerable in 3.8.0-->
-				<exclusion>
-					<groupId>commons-io</groupId>
-					<artifactId>commons-io</artifactId>
-				</exclusion>
-				<exclusion>
-					<groupId>commons-fileupload</groupId>
-					<artifactId>commons-fileupload</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>commons-fileupload</groupId>
-			<artifactId>commons-fileupload</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>io.github.openfeign</groupId>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -16,7 +16,6 @@
 	<description>Spring Cloud OpenFeign Dependencies</description>
 	<properties>
 		<feign.version>13.5</feign.version>
-		<feign-form.version>3.8.0</feign-form.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>
@@ -36,22 +35,6 @@
 				<version>${feign.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
-			</dependency>
-			<dependency>
-				<groupId>io.github.openfeign.form</groupId>
-				<artifactId>feign-form-spring</artifactId>
-				<version>${feign-form.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>commons-fileupload</groupId>
-						<artifactId>commons-fileupload</artifactId>
-					</exclusion>
-				</exclusions>
-			</dependency>
-			<dependency>
-				<groupId>commons-fileupload</groupId>
-				<artifactId>commons-fileupload</artifactId>
-				<version>1.5</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
This PR backports #1103 to the 4.1.x branch.