### PR TITLE
Dynamically set the url of FeignClient through config

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,14 @@
 				<groupId>io.spring.javaformat</groupId>
 				<artifactId>spring-javaformat-maven-plugin</artifactId>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.6</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -102,6 +102,18 @@
 			</dependency>
 		</dependencies>
 	</dependencyManagement>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-gpg-plugin</artifactId>
+				<version>1.6</version>
+				<configuration>
+					<skip>true</skip>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
 	<profiles>
 		<profile>
 			<id>spring</id>


### PR DESCRIPTION
Dynamically set the url of FeignClient:

as known if a service have some nodes, we can set the url of the FeignClient to call the certain node。
now i want set the url of FeignClient dynamically in the class FeignClientsRegistrar.java through the config contents of bootstrap.yml.
as:
![appoint](https://github.com/user-attachments/assets/47d660aa-6e77-4d5b-8dd0-9b50f3de076e)
then,  call the service message-api will through the url  192.168.2.39:1201