### PR TITLE
docs: Improve SpringQueryMap documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,7 +17,7 @@ given the ability to merge pull requests.
 
 ## Code of Conduct
 This project adheres to the Contributor Covenant [code of
-conduct](https://github.com/spring-cloud/spring-cloud-build/blob/main/docs/src/main/asciidoc/code-of-conduct.adoc). By participating, you  are expected to uphold this code. Please report
+conduct](https://github.com/spring-cloud/spring-cloud-build/blob/main/docs/modules/ROOT/partials/code-of-conduct.adoc). By participating, you  are expected to uphold this code. Please report
 unacceptable behavior to spring-code-of-conduct@pivotal.io.
 
 ## Code Conventions and Housekeeping

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,17 +2,12 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "3.1.x" # oldest OSS supported branch
+    target-branch: "4.1.x" # oldest OSS supported branch
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "4.0.x" # oldest OSS supported branch
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    target-branch: "4.1.x"
+    target-branch: "4.2.x"
     schedule:
       interval: "weekly"
   - package-ecosystem: "github-actions"
@@ -24,29 +19,18 @@ updates:
     directory: /
     schedule:
       interval: daily
-    target-branch: 3.1.x
-    ignore:
-      # only upgrade patch versions for maintenance branch
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
-  - package-ecosystem: maven
-    directory: /
-    schedule:
-      interval: daily
-    target-branch: 4.0.x
-    ignore:
-      # only upgrade patch versions for maintenance branch
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
-  - package-ecosystem: maven
-    directory: /
-    schedule:
-      interval: daily
     target-branch: 4.1.x
+    ignore:
+      # only upgrade patch versions for maintenance branch
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: daily
+    target-branch: 4.2.x
     ignore:
       # only upgrade patch versions for maintenance branch
       - dependency-name: "*"
@@ -75,6 +59,11 @@ updates:
       interval: weekly
   - package-ecosystem: npm
     target-branch: 4.1.x
+    directory: /docs
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    target-branch: 4.2.x
     directory: /docs
     schedule:
       interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,3 +63,18 @@ updates:
       - dependency-name: "*"
         update-types:
           - version-update:semver-major
+  - package-ecosystem: npm
+    target-branch: docs-build
+    directory: /
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    target-branch: main
+    directory: /docs
+    schedule:
+      interval: weekly
+  - package-ecosystem: npm
+    target-branch: 4.1.x
+    directory: /docs
+    schedule:
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
       interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
+    target-branch: "4.1.x"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
     target-branch: "main"
     schedule:
       interval: "weekly"
@@ -31,6 +36,17 @@ updates:
     schedule:
       interval: daily
     target-branch: 4.0.x
+    ignore:
+      # only upgrade patch versions for maintenance branch
+      - dependency-name: "*"
+        update-types:
+          - version-update:semver-major
+          - version-update:semver-minor
+  - package-ecosystem: maven
+    directory: /
+    schedule:
+      interval: daily
+    target-branch: 4.1.x
     ignore:
       # only upgrade patch versions for maintenance branch
       - dependency-name: "*"

--- a/docs/modules/ROOT/pages/spring-cloud-openfeign.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-openfeign.adoc
@@ -146,7 +146,25 @@ When it comes to the Apache HttpClient 5-backed Feign clients, it's enough to en
 You can customize the HTTP client used by providing a bean of either `org.apache.hc.client5.http.impl.classic.CloseableHttpClient` when using Apache HC5.
 
 You can further customise http clients by setting values in the `spring.cloud.openfeign.httpclient.xxx` properties. The ones prefixed just with `httpclient` will work for all the clients, the ones prefixed with `httpclient.hc5` to Apache HttpClient 5, the ones prefixed with `httpclient.okhttp` to OkHttpClient and the ones prefixed with `httpclient.http2` to Http2Client. You can find a full list of properties you can customise in the appendix.
-If you can not configure Apache HttpClient 5 by using properties, there is an `HttpClientBuilderCustomizer` interface for programmatic configuration.
+If you can not configure Apache HttpClient 5 by using properties, there is an `HttpClient5FeignConfiguration.HttpClientBuilderCustomizer` interface for programmatic configuration.
+
+TIP: Apache HTTP Components `5.4` have changed defaults in the HttpClient relating to HTTP/1.1 TLS upgrades. Most proxy servers handle upgrades without issue, however, you may encounter issues with Envoy or Istio. If you need to restore previous behaviour, you can use `HttpClient5FeignConfiguration.HttpClientBuilderCustomizer` to do it, as shown in the example below.
+
+[source,java,indent=0]
+----
+@Configuration
+public class FooConfiguration {
+
+	@Bean
+	public HttpClient5FeignConfiguration.HttpClientBuilderCustomizer httpClientBuilder() {
+		return (httpClientBuilder) -> {
+			RequestConfig.Builder requestConfigBuilder = RequestConfig.custom();
+			requestConfigBuilder.setProtocolUpgradeEnabled(false);
+			httpClientBuilder.setDefaultRequestConfig(requestConfigBuilder.build());
+		};
+	}
+}
+----
 
 TIP: Starting with Spring Cloud OpenFeign 4, the Feign Apache HttpClient 4 is no longer supported. We suggest using Apache HttpClient 5 instead.
 

--- a/docs/modules/ROOT/partials/_configprops.adoc
+++ b/docs/modules/ROOT/partials/_configprops.adoc
@@ -1,7 +1,7 @@
 |===
 |Name | Default | Description
 
-|spring.cloud.compatibility-verifier.compatible-boot-versions | `+++3.4.x+++` | Default accepted versions for the Spring Boot dependency. You can set {@code x} for the patch version if you don't want to specify a concrete value. Example: {@code 3.4.x}
+|spring.cloud.compatibility-verifier.compatible-boot-versions | `+++3.5.x+++` | Default accepted versions for the Spring Boot dependency. You can set {@code x} for the patch version if you don't want to specify a concrete value. Example: {@code 3.5.x}
 |spring.cloud.compatibility-verifier.enabled | `+++false+++` | Enables creation of Spring Cloud compatibility verification.
 |spring.cloud.config.allow-override | `+++true+++` | Flag to indicate that {@link #isOverrideSystemProperties() systemPropertiesOverride} can be used. Set to false to prevent users from changing the default accidentally. Default true.
 |spring.cloud.config.initialize-on-context-refresh | `+++false+++` | Flag to initialize bootstrap configuration on context refresh event. Default false.

--- a/docs/modules/ROOT/partials/_configprops.adoc
+++ b/docs/modules/ROOT/partials/_configprops.adoc
@@ -107,8 +107,8 @@
 |spring.cloud.openfeign.okhttp.enabled | `+++false+++` | Enables the use of the OK HTTP Client by Feign.
 |spring.cloud.refresh.additional-property-sources-to-retain |  | Additional property sources to retain during a refresh. Typically only system property sources are retained. This property allows property sources, such as property sources created by EnvironmentPostProcessors to be retained as well.
 |spring.cloud.refresh.enabled | `+++true+++` | Enables autoconfiguration for the refresh scope and associated features.
-|spring.cloud.refresh.extra-refreshable | `+++true+++` | Additional class names for beans to post process into refresh scope.
-|spring.cloud.refresh.never-refreshable | `+++true+++` | Comma separated list of class names for beans to never be refreshed or rebound.
+|spring.cloud.refresh.extra-refreshable | `+++true+++` | Additional bean names or class names for beans to post process into refresh scope.
+|spring.cloud.refresh.never-refreshable | `+++true+++` | Comma separated list of bean names or class names for beans to never be refreshed or rebound.
 |spring.cloud.refresh.on-restart.enabled | `+++true+++` | Enable refreshing context on start.
 |spring.cloud.service-registry.auto-registration.enabled | `+++true+++` | Whether service auto-registration is enabled. Defaults to true.
 |spring.cloud.service-registry.auto-registration.fail-fast | `+++false+++` | Whether startup fails if there is no AutoServiceRegistration. Defaults to false.

--- a/docs/modules/ROOT/partials/_configprops.adoc
+++ b/docs/modules/ROOT/partials/_configprops.adoc
@@ -65,7 +65,7 @@
 |spring.cloud.loadbalancer.subset.size | `+++100+++` | Max subset size of deterministic subsetting.
 |spring.cloud.loadbalancer.x-forwarded.enabled | `+++false+++` | To Enable X-Forwarded Headers.
 |spring.cloud.openfeign.autoconfiguration.jackson.enabled | `+++true+++` | If true, PageJacksonModule and SortJacksonModule bean will be provided for Jackson page decoding.
-|spring.cloud.openfeign.circuitbreaker.alphanumeric-ids.enabled | `+++false+++` | If true, Circuit Breaker ids will only contain alphanumeric characters to allow for configuration via configuration properties.
+|spring.cloud.openfeign.circuitbreaker.alphanumeric-ids.enabled | `+++true+++` | If true, Circuit Breaker ids will only contain alphanumeric characters to allow for configuration via configuration properties.
 |spring.cloud.openfeign.circuitbreaker.enabled | `+++false+++` | If true, an OpenFeign client will be wrapped with a Spring Cloud CircuitBreaker circuit breaker.
 |spring.cloud.openfeign.circuitbreaker.group.enabled | `+++false+++` | If true, an OpenFeign client will be wrapped with a Spring Cloud CircuitBreaker circuit breaker with group.
 |spring.cloud.openfeign.client.config |  | 

--- a/docs/modules/ROOT/partials/_configprops.adoc
+++ b/docs/modules/ROOT/partials/_configprops.adoc
@@ -58,6 +58,7 @@
 |spring.cloud.loadbalancer.retry.retry-on-all-operations | `+++false+++` | Indicates retries should be attempted on operations other than `HttpMethod.GET`.
 |spring.cloud.loadbalancer.retry.retryable-exceptions | `+++{}+++` | A `Set` of `Throwable` classes that should trigger a retry.
 |spring.cloud.loadbalancer.retry.retryable-status-codes | `+++{}+++` | A `Set` of status codes that should trigger a retry.
+|spring.cloud.loadbalancer.stats.include-path | `+++true+++` | Indicates whether the {@code path} should be added to {@code uri} tag in metrics. When {@link RestTemplate} is used to execute load-balanced requests with high cardinality paths, setting it to {@code false} is recommended.
 |spring.cloud.loadbalancer.stats.micrometer.enabled | `+++false+++` | Enables micrometer metrics for load-balanced requests.
 |spring.cloud.loadbalancer.sticky-session.add-service-instance-cookie | `+++false+++` | Indicates whether a cookie with the newly selected instance should be added by LoadBalancer.
 |spring.cloud.loadbalancer.sticky-session.instance-id-cookie-name | `+++sc-lb-instance-id+++` | The name of the cookie holding the preferred instance id.

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"antora": "3.2.0-alpha.6",
 		"@antora/atlas-extension": "1.0.0-alpha.2",
-		"@antora/collector-extension": "1.0.0-beta.5",
+		"@antora/collector-extension": "1.0.0-rc.1",
 		"@asciidoctor/tabs": "1.0.0-beta.6",
 		"@springio/antora-extensions": "1.14.2",
 		"@springio/asciidoctor-extensions": "1.0.0-alpha.14"

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"antora": "3.2.0-alpha.6",
 		"@antora/atlas-extension": "1.0.0-alpha.2",
-		"@antora/collector-extension": "1.0.0-beta.3",
+		"@antora/collector-extension": "1.0.0-beta.5",
 		"@asciidoctor/tabs": "1.0.0-beta.6",
 		"@springio/antora-extensions": "1.14.2",
 		"@springio/asciidoctor-extensions": "1.0.0-alpha.14"

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"antora": "3.2.0-alpha.6",
+		"antora": "3.2.0-alpha.8",
 		"@antora/atlas-extension": "1.0.0-alpha.2",
 		"@antora/collector-extension": "1.0.0-rc.1",
 		"@asciidoctor/tabs": "1.0.0-beta.6",

--- a/docs/package.json
+++ b/docs/package.json
@@ -2,7 +2,7 @@
 	"dependencies": {
 		"antora": "3.2.0-alpha.8",
 		"@antora/atlas-extension": "1.0.0-alpha.2",
-		"@antora/collector-extension": "1.0.0-rc.1",
+		"@antora/collector-extension": "1.0.1",
 		"@asciidoctor/tabs": "1.0.0-beta.6",
 		"@springio/antora-extensions": "1.14.2",
 		"@springio/asciidoctor-extensions": "1.0.0-alpha.14"

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.3.0-M1</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-M2</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-RC1</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.0-M1</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-RC1</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -8,7 +8,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-M2</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -30,12 +30,12 @@
 		<micrometer-docs-generator.inclusionPattern>.*</micrometer-docs-generator.inclusionPattern>
 		<micrometer-docs-generator.outputPath>${maven.multiModuleProjectDirectory}/docs/modules/ROOT/partials/</micrometer-docs-generator.outputPath>
 	</properties>
-	<dependencies>
+<!-- 	<dependencies>
 		<dependency>
 			<groupId>${project.groupId}</groupId>
 			<artifactId>spring-cloud-starter-openfeign</artifactId>
 		</dependency>
-	</dependencies>
+	</dependencies> -->
 	<build>
 		<sourceDirectory>src/main/asciidoc</sourceDirectory>
 	</build>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-RC1</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-RC1</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.1</jackson.version>
-		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.2.0-RC1</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
 				<configuration>
 					<ignoredResourcePatterns>
 						<ignoredResourcePattern>mozilla/public-suffix-list.txt</ignoredResourcePattern>
+						<ignoredResourcePattern>mockito-extensions/org.mockito.plugins.MockResolver</ignoredResourcePattern>
 					</ignoredResourcePatterns>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.2</jackson.version>
-		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.2.1-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	</scm>
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
-		<jackson.version>2.18.1</jackson.version>
+		<jackson.version>2.18.2</jackson.version>
 		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.2</jackson.version>
-		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.2.0</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-M2</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-M2</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.0</jackson.version>
-		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.2.0-M2</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.2.0</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.2.0</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.2</jackson.version>
-		<spring-cloud-commons.version>4.2.0</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	</scm>
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
-		<jackson.version>2.17.2</jackson.version>
+		<jackson.version>2.18.0</jackson.version>
 		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.2</jackson.version>
-		<spring-cloud-commons.version>4.2.1-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.3.0-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.2.1-SNAPSHOT</version>
+	<version>4.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<scm>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.2.0-M2</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.2.0-M2</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.0</jackson.version>
-		<spring-cloud-commons.version>4.2.0-M2</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 	</scm>
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
-		<jackson.version>2.18.0</jackson.version>
+		<jackson.version>2.18.1</jackson.version>
 		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.3.0-M1</version>
+	<version>4.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.3.0-M1</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.2</jackson.version>
-		<spring-cloud-commons.version>4.3.0-M1</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.3.0-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.2</jackson.version>
-		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.2.1-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.3.0-SNAPSHOT</version>
+	<version>4.3.0-M1</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.0-M1</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.2</jackson.version>
-		<spring-cloud-commons.version>4.3.0-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.3.0-M1</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.2.1-SNAPSHOT</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.2</jackson.version>
-		<spring-cloud-commons.version>4.2.1-SNAPSHOT</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>spring-cloud-openfeign</artifactId>
-	<version>4.2.0-RC1</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>Spring Cloud OpenFeign</name>
 	<description>Spring Cloud OpenFeign</description>
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>4.2.0-RC1</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<scm>
@@ -26,7 +26,7 @@
 	<properties>
 		<main.basedir>${basedir}</main.basedir>
 		<jackson.version>2.18.1</jackson.version>
-		<spring-cloud-commons.version>4.2.0-RC1</spring-cloud-commons.version>
+		<spring-cloud-commons.version>4.2.0-SNAPSHOT</spring-cloud-commons.version>
 
 		<!-- Plugin versions -->
 		<maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -93,7 +93,6 @@
 		<dependency>
 			<groupId>io.github.openfeign</groupId>
 			<artifactId>feign-form-spring</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.github.openfeign</groupId>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-M2</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -200,7 +200,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.16.1</version>
+			<version>2.17.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-RC1</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-M2</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.3.0-M1</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.0-M1</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -185,7 +185,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.17.0</version>
+			<version>2.18.0</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -93,6 +93,7 @@
 		<dependency>
 			<groupId>io.github.openfeign</groupId>
 			<artifactId>feign-form-spring</artifactId>
+			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>io.github.openfeign</groupId>

--- a/spring-cloud-openfeign-core/pom.xml
+++ b/spring-cloud-openfeign-core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-RC1</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath> <!-- lookup parent from repository -->
 	</parent>
 	<scm>

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,6 +67,7 @@ import org.springframework.util.StringUtils;
  * @author Marcin Grzejszczak
  * @author Olga Maciaszek-Sharma
  * @author Jasbir Singh
+ * @author Jinho Lee
  */
 class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLoaderAware, EnvironmentAware {
 
@@ -321,11 +322,7 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 		validateFallbackFactory(annotation.getClass("fallbackFactory"));
 	}
 
-	/* for testing */ String getName(Map<String, Object> attributes) {
-		return getName(null, attributes);
-	}
-
-	String getName(ConfigurableBeanFactory beanFactory, Map<String, Object> attributes) {
+	String getName(Map<String, Object> attributes) {
 		String name = (String) attributes.get("serviceId");
 		if (!StringUtils.hasText(name)) {
 			name = (String) attributes.get("name");
@@ -333,7 +330,7 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 		if (!StringUtils.hasText(name)) {
 			name = (String) attributes.get("value");
 		}
-		name = resolve(beanFactory, name);
+		name = resolve(null, name);
 		return getName(name);
 	}
 

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
@@ -118,9 +118,6 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 			if (!url.contains("://")) {
 				url = "http://" + url;
 			}
-			if (url.endsWith("/")) {
-				url = url.substring(0, url.length() - 1);
-			}
 			try {
 				new URL(url);
 			}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
@@ -118,6 +118,9 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 			if (!url.contains("://")) {
 				url = "http://" + url;
 			}
+			if (url.endsWith("/")) {
+				url = url.substring(0, url.length() - 1);
+			}
 			try {
 				new URL(url);
 			}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/SpringQueryMap.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/SpringQueryMap.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Target;
  *
  * @author Aram Peres
  * @see feign.QueryMap
+ * @see feign.QueryMapEncoder
+ * @see org.springframework.cloud.openfeign.FeignClientsConfiguration
  * @see org.springframework.cloud.openfeign.annotation.QueryMapParameterProcessor
  */
 @Retention(RetentionPolicy.RUNTIME)

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/encoding/FeignClientEncodingProperties.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/encoding/FeignClientEncodingProperties.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -25,6 +25,7 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  * The Feign encoding properties.
  *
  * @author Jakub Narloch
+ * @author André Teigler
  */
 @ConfigurationProperties("spring.cloud.openfeign.compression.request")
 public class FeignClientEncodingProperties {
@@ -38,6 +39,11 @@ public class FeignClientEncodingProperties {
 	 * The minimum threshold content size.
 	 */
 	private int minRequestSize = 2048;
+
+	/**
+	 * The list of content encodings (applicable encodings depend on the used client).
+	 */
+	private String[] contentEncodingTypes = new String[] { HttpEncoding.GZIP_ENCODING, HttpEncoding.DEFLATE_ENCODING };
 
 	public String[] getMimeTypes() {
 		return mimeTypes;
@@ -55,6 +61,14 @@ public class FeignClientEncodingProperties {
 		this.minRequestSize = minRequestSize;
 	}
 
+	public String[] getContentEncodingTypes() {
+		return contentEncodingTypes;
+	}
+
+	public void setContentEncodingTypes(String[] contentEncodingTypes) {
+		this.contentEncodingTypes = contentEncodingTypes;
+	}
+
 	@Override
 	public boolean equals(Object o) {
 		if (this == o) {
@@ -64,7 +78,8 @@ public class FeignClientEncodingProperties {
 			return false;
 		}
 		FeignClientEncodingProperties that = (FeignClientEncodingProperties) o;
-		return Arrays.equals(mimeTypes, that.mimeTypes) && Objects.equals(minRequestSize, that.minRequestSize);
+		return Arrays.equals(mimeTypes, that.mimeTypes) && Objects.equals(minRequestSize, that.minRequestSize)
+				&& Arrays.equals(contentEncodingTypes, that.contentEncodingTypes);
 	}
 
 	@Override
@@ -79,6 +94,9 @@ public class FeignClientEncodingProperties {
 			.append(", ")
 			.append("minRequestSize=")
 			.append(minRequestSize)
+			.append(", ")
+			.append("contentEncodingTypes=")
+			.append(Arrays.toString(contentEncodingTypes))
 			.append("}")
 			.toString();
 	}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/encoding/FeignContentGzipEncodingInterceptor.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/encoding/FeignContentGzipEncodingInterceptor.java
@@ -44,9 +44,18 @@ public class FeignContentGzipEncodingInterceptor extends BaseRequestInterceptor 
 	public void apply(RequestTemplate template) {
 
 		if (requiresCompression(template)) {
-			addHeader(template, HttpEncoding.CONTENT_ENCODING_HEADER, HttpEncoding.GZIP_ENCODING,
-					HttpEncoding.DEFLATE_ENCODING);
+			addHeader(template, HttpEncoding.CONTENT_ENCODING_HEADER, getContentEncodings());
 		}
+	}
+
+	private String[] getContentEncodings() {
+		if (getProperties().getContentEncodingTypes() == null
+				|| getProperties().getContentEncodingTypes().length == 0) {
+
+			throw new IllegalStateException("Invalid ContentEncodingTypes configuration");
+		}
+
+		return getProperties().getContentEncodingTypes();
 	}
 
 	/**

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/FeignBlockingLoadBalancerClient.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/FeignBlockingLoadBalancerClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ public class FeignBlockingLoadBalancerClient implements Client {
 	 * @deprecated in favour of
 	 * {@link FeignBlockingLoadBalancerClient#FeignBlockingLoadBalancerClient(Client, LoadBalancerClient, LoadBalancerClientFactory, List)}
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public FeignBlockingLoadBalancerClient(Client delegate, LoadBalancerClient loadBalancerClient,
 			LoadBalancerProperties properties, LoadBalancerClientFactory loadBalancerClientFactory) {
 		this.delegate = delegate;
@@ -84,7 +84,7 @@ public class FeignBlockingLoadBalancerClient implements Client {
 	 * @deprecated in favour of
 	 * {@link FeignBlockingLoadBalancerClient#FeignBlockingLoadBalancerClient(Client, LoadBalancerClient, LoadBalancerClientFactory, List)}
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public FeignBlockingLoadBalancerClient(Client delegate, LoadBalancerClient loadBalancerClient,
 			LoadBalancerClientFactory loadBalancerClientFactory) {
 		this.delegate = delegate;

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/RetryableFeignBlockingLoadBalancerClient.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/loadbalancer/RetryableFeignBlockingLoadBalancerClient.java
@@ -90,7 +90,7 @@ public class RetryableFeignBlockingLoadBalancerClient implements Client {
 	 * @deprecated in favour of
 	 * {@link RetryableFeignBlockingLoadBalancerClient#RetryableFeignBlockingLoadBalancerClient(Client, LoadBalancerClient, LoadBalancedRetryFactory, LoadBalancerClientFactory, List)}
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public RetryableFeignBlockingLoadBalancerClient(Client delegate, LoadBalancerClient loadBalancerClient,
 			LoadBalancedRetryFactory loadBalancedRetryFactory, LoadBalancerProperties properties,
 			LoadBalancerClientFactory loadBalancerClientFactory) {
@@ -105,7 +105,7 @@ public class RetryableFeignBlockingLoadBalancerClient implements Client {
 	 * @deprecated in favour of
 	 * {@link RetryableFeignBlockingLoadBalancerClient#RetryableFeignBlockingLoadBalancerClient(Client, LoadBalancerClient, LoadBalancedRetryFactory, LoadBalancerClientFactory, List)}
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public RetryableFeignBlockingLoadBalancerClient(Client delegate, LoadBalancerClient loadBalancerClient,
 			LoadBalancedRetryFactory loadBalancedRetryFactory, LoadBalancerClientFactory loadBalancerClientFactory) {
 		this.delegate = delegate;

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -33,6 +33,7 @@ import org.springframework.data.domain.Sort;
  *
  * @author Pascal Büttiker
  * @author Yanming Zhou
+ * @author Gokalp Kuscu
  */
 public class PageableSpringEncoder implements Encoder {
 
@@ -52,6 +53,11 @@ public class PageableSpringEncoder implements Encoder {
 	 * Sort parameter name.
 	 */
 	private String sortParameter = "sort";
+
+	/**
+	 * Sort ignoreCase parameter name.
+	 */
+	private final String ignoreCase = "ignorecase";
 
 	/**
 	 * Creates a new PageableSpringEncoder with the given delegate for fallback. If no
@@ -115,7 +121,11 @@ public class PageableSpringEncoder implements Encoder {
 			}
 		}
 		for (Sort.Order order : sort) {
-			sortQueries.add(order.getProperty() + "%2C" + order.getDirection());
+			String sortQuery = order.getProperty() + "%2C" + order.getDirection();
+			if (order.isIgnoreCase()) {
+				sortQuery += "%2C" + ignoreCase;
+			}
+			sortQueries.add(sortQuery);
 		}
 		if (!sortQueries.isEmpty()) {
 			template.query(sortParameter, sortQueries);

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2022 the original author or authors.
+ * Copyright 2013-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,6 +32,7 @@ import org.springframework.data.domain.Sort;
  *
  * @author Hyeonmin Park
  * @author Yanming Zhou
+ * @author Gokalp Kuscu
  * @since 2.2.8
  */
 public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
@@ -50,6 +51,11 @@ public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
 	 * Sort parameter name.
 	 */
 	private String sortParameter = "sort";
+
+	/**
+	 * Sort ignoreCase parameter name.
+	 */
+	private final String ignoreCase = "ignorecase";
 
 	public void setPageParameter(String pageParameter) {
 		this.pageParameter = pageParameter;
@@ -92,7 +98,11 @@ public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
 	private void applySort(Map<String, Object> queryMap, Sort sort) {
 		List<String> sortQueries = new ArrayList<>();
 		for (Sort.Order order : sort) {
-			sortQueries.add(order.getProperty() + "%2C" + order.getDirection());
+			String sortQuery = order.getProperty() + "%2C" + order.getDirection();
+			if (order.isIgnoreCase()) {
+				sortQuery += "%2C" + ignoreCase;
+			}
+			sortQueries.add(sortQuery);
 		}
 		if (!sortQueries.isEmpty()) {
 			queryMap.put(sortParameter, sortQueries);

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SortJsonComponent.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SortJsonComponent.java
@@ -39,6 +39,7 @@ import org.springframework.data.domain.Sort;
  *
  * @author Can Bezmen
  * @author Olga Maciaszek-Sharma
+ * @author Gokalp Kuscu
  */
 public class SortJsonComponent {
 
@@ -90,8 +91,23 @@ public class SortJsonComponent {
 		private static Sort toSort(ArrayNode arrayNode) {
 			List<Sort.Order> orders = new ArrayList<>();
 			for (JsonNode jsonNode : arrayNode) {
-				Sort.Order order = new Sort.Order(Sort.Direction.valueOf(jsonNode.get("direction").textValue()),
-						jsonNode.get("property").textValue());
+				Sort.Order order;
+				// there is no way to construct without null handling
+				if ((jsonNode.has("ignoreCase") && jsonNode.get("ignoreCase").isBoolean())
+						&& jsonNode.has("nullHandling") && jsonNode.get("nullHandling").isTextual()) {
+
+					boolean ignoreCase = jsonNode.get("ignoreCase").asBoolean();
+					String nullHandlingValue = jsonNode.get("nullHandling").textValue();
+
+					order = new Sort.Order(Sort.Direction.valueOf(jsonNode.get("direction").textValue()),
+							jsonNode.get("property").textValue(), ignoreCase,
+							Sort.NullHandling.valueOf(nullHandlingValue));
+				}
+				else {
+					// backward compatibility
+					order = new Sort.Order(Sort.Direction.valueOf(jsonNode.get("direction").textValue()),
+							jsonNode.get("property").textValue());
+				}
 				orders.add(order);
 			}
 			return Sort.by(orders);

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringDecoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringDecoder.java
@@ -87,11 +87,12 @@ public class SpringDecoder implements Decoder {
 			return HttpStatusCode.valueOf(response.status());
 		}
 
-		@Deprecated
 		/**
 		 * This method used to override a method from ClientHttpResponse interface but was
-		 * removed in Spring Framework 6.2 so we should remove it as well.
+		 * removed in Spring Framework 6.2, so we should remove it as well.
+		 * @deprecated in favour of {@link SpringDecoder.FeignResponseAdapter#getStatusCode()}
 		 */
+		@Deprecated(forRemoval = true)
 		public int getRawStatusCode() {
 			return response.status();
 		}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringDecoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringDecoder.java
@@ -90,7 +90,8 @@ public class SpringDecoder implements Decoder {
 		/**
 		 * This method used to override a method from ClientHttpResponse interface but was
 		 * removed in Spring Framework 6.2, so we should remove it as well.
-		 * @deprecated in favour of {@link SpringDecoder.FeignResponseAdapter#getStatusCode()}
+		 * @deprecated in favour of
+		 * {@link SpringDecoder.FeignResponseAdapter#getStatusCode()}
 		 */
 		@Deprecated(forRemoval = true)
 		public int getRawStatusCode() {

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -141,7 +141,7 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 	 * @deprecated in favour of
 	 * {@link SpringMvcContract#SpringMvcContract(List, ConversionService, FeignClientProperties)}
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public SpringMvcContract(List<AnnotatedParameterProcessor> annotatedParameterProcessors,
 			ConversionService conversionService, boolean decodeSlash) {
 		this(annotatedParameterProcessors, conversionService, decodeSlash, false);
@@ -158,7 +158,7 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 	 * @deprecated in favour of
 	 * {@link SpringMvcContract#SpringMvcContract(List, ConversionService, FeignClientProperties)}
 	 */
-	@Deprecated
+	@Deprecated(forRemoval = true)
 	public SpringMvcContract(List<AnnotatedParameterProcessor> annotatedParameterProcessors,
 			ConversionService conversionService, boolean decodeSlash, boolean removeTrailingSlash) {
 		Assert.notNull(annotatedParameterProcessors, "Parameter processors can not be null.");

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientBuilderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientBuilderTests.java
@@ -131,7 +131,7 @@ class FeignClientBuilderTests {
 		assertFactoryBeanField(builder, "contextId", "TestContext");
 
 		// and:
-		assertFactoryBeanField(builder, "url", "http://Url/");
+		assertFactoryBeanField(builder, "url", "http://Url");
 		assertFactoryBeanField(builder, "path", "/Path");
 		assertFactoryBeanField(builder, "dismiss404", true);
 
@@ -155,7 +155,7 @@ class FeignClientBuilderTests {
 		assertFactoryBeanField(builder, "contextId", "TestContext");
 
 		// and:
-		assertFactoryBeanField(builder, "url", "http://Url/");
+		assertFactoryBeanField(builder, "url", "http://Url");
 		assertFactoryBeanField(builder, "path", "/Path");
 		assertFactoryBeanField(builder, "dismiss404", true);
 		List<FeignBuilderCustomizer> additionalCustomizers = getFactoryBeanField(builder, "additionalCustomizers");

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientsRegistrarTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignClientsRegistrarTests.java
@@ -90,6 +90,12 @@ class FeignClientsRegistrarTests {
 	}
 
 	@Test
+	void removeLastSlashOfUrl() {
+		String url = FeignClientsRegistrar.getUrl("http://localhost/");
+		assertThat(url).isEqualTo("http://localhost");
+	}
+
+	@Test
 	void testFallback() {
 		assertThatExceptionOfType(IllegalArgumentException.class)
 			.isThrownBy(() -> new AnnotationConfigApplicationContext(FallbackTestConfig.class));

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignContentGzipEncodingInterceptorTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/FeignContentGzipEncodingInterceptorTests.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2013-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.encoding;
+
+import java.util.List;
+
+import feign.RequestTemplate;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link FeignContentGzipEncodingInterceptor}.
+ *
+ * @author André Teigler
+ */
+class FeignContentGzipEncodingInterceptorTests {
+
+	@Test
+	void shouldNotAddCompressionHeaderWhenSizeBelowThreshold() {
+		final FeignClientEncodingProperties properties = new FeignClientEncodingProperties();
+		final RequestTemplate template = new RequestTemplate();
+		template.header(HttpEncoding.CONTENT_LENGTH, "2047");
+		template.header(HttpEncoding.CONTENT_TYPE, "application/json");
+		final FeignContentGzipEncodingInterceptor interceptor = new FeignContentGzipEncodingInterceptor(properties);
+
+		interceptor.apply(template);
+
+		assertThat(template.headers()).doesNotContainKey(HttpEncoding.CONTENT_ENCODING_HEADER);
+	}
+
+	@Test
+	void shouldNotAddCompressionHeaderWhenSizeEqualsThreshold() {
+		final FeignClientEncodingProperties properties = new FeignClientEncodingProperties();
+		final RequestTemplate template = new RequestTemplate();
+		template.header(HttpEncoding.CONTENT_LENGTH, "2048");
+		template.header(HttpEncoding.CONTENT_TYPE, "application/json");
+		final FeignContentGzipEncodingInterceptor interceptor = new FeignContentGzipEncodingInterceptor(properties);
+
+		interceptor.apply(template);
+
+		assertThat(template.headers()).doesNotContainKey(HttpEncoding.CONTENT_ENCODING_HEADER);
+	}
+
+	@Test
+	void shouldAddCompressionHeaderWhenSizeAboveThreshold() {
+		final FeignClientEncodingProperties properties = new FeignClientEncodingProperties();
+		final RequestTemplate template = new RequestTemplate();
+		template.header(HttpEncoding.CONTENT_LENGTH, "2049");
+		template.header(HttpEncoding.CONTENT_TYPE, "application/json");
+		final FeignContentGzipEncodingInterceptor interceptor = new FeignContentGzipEncodingInterceptor(properties);
+
+		interceptor.apply(template);
+
+		assertThat(template.headers()).containsKey(HttpEncoding.CONTENT_ENCODING_HEADER);
+		assertThat(template.headers().get(HttpEncoding.CONTENT_ENCODING_HEADER)).isEqualTo(List.of("gzip", "deflate"));
+	}
+
+	@Test
+	void shouldNotAddCompressionHeaderWhenTypeMismatch() {
+		final FeignClientEncodingProperties properties = new FeignClientEncodingProperties();
+		properties.setMimeTypes(new String[] { "application/xml" });
+		final RequestTemplate template = new RequestTemplate();
+		template.header(HttpEncoding.CONTENT_LENGTH, "2049");
+		template.header(HttpEncoding.CONTENT_TYPE, "application/json");
+		final FeignContentGzipEncodingInterceptor interceptor = new FeignContentGzipEncodingInterceptor(properties);
+
+		interceptor.apply(template);
+
+		assertThat(template.headers()).doesNotContainKey(HttpEncoding.CONTENT_ENCODING_HEADER);
+	}
+
+	@Test
+	void shouldAddDefaultCompressionHeaderWhenMimeTypeNotSet() {
+		final FeignClientEncodingProperties properties = new FeignClientEncodingProperties();
+		properties.setMimeTypes(new String[] {});
+		final RequestTemplate template = new RequestTemplate();
+		template.header(HttpEncoding.CONTENT_LENGTH, "2049");
+		template.header(HttpEncoding.CONTENT_TYPE, "application/json");
+		final FeignContentGzipEncodingInterceptor interceptor = new FeignContentGzipEncodingInterceptor(properties);
+
+		interceptor.apply(template);
+
+		assertThat(template.headers()).containsKey(HttpEncoding.CONTENT_ENCODING_HEADER);
+		assertThat(template.headers().get(HttpEncoding.CONTENT_ENCODING_HEADER)).isEqualTo(List.of("gzip", "deflate"));
+	}
+
+	@Test
+	void shouldAddDefaultCompressionHeaderWhenNullMimeTypeSet() {
+		final FeignClientEncodingProperties properties = new FeignClientEncodingProperties();
+		properties.setMimeTypes(null);
+		final RequestTemplate template = new RequestTemplate();
+		template.header(HttpEncoding.CONTENT_LENGTH, "2049");
+		template.header(HttpEncoding.CONTENT_TYPE, "application/json");
+		final FeignContentGzipEncodingInterceptor interceptor = new FeignContentGzipEncodingInterceptor(properties);
+
+		interceptor.apply(template);
+
+		assertThat(template.headers()).containsKey(HttpEncoding.CONTENT_ENCODING_HEADER);
+		assertThat(template.headers().get(HttpEncoding.CONTENT_ENCODING_HEADER)).isEqualTo(List.of("gzip", "deflate"));
+	}
+
+	@Test
+	void shouldAddCustomCompressionHeader() {
+		final FeignClientEncodingProperties properties = new FeignClientEncodingProperties();
+		properties.setContentEncodingTypes(new String[] { "gzip" });
+		final RequestTemplate template = new RequestTemplate();
+		template.header(HttpEncoding.CONTENT_LENGTH, "2049");
+		template.header(HttpEncoding.CONTENT_TYPE, "application/json");
+		final FeignContentGzipEncodingInterceptor interceptor = new FeignContentGzipEncodingInterceptor(properties);
+
+		interceptor.apply(template);
+
+		assertThat(template.headers()).containsKey(HttpEncoding.CONTENT_ENCODING_HEADER);
+		assertThat(template.headers().get(HttpEncoding.CONTENT_ENCODING_HEADER)).isEqualTo(List.of("gzip"));
+	}
+
+	@Test
+	void shouldThrowExceptionWhenContentEncodingTypesAreEmpty() {
+		final FeignClientEncodingProperties properties = new FeignClientEncodingProperties();
+		properties.setContentEncodingTypes(new String[] {});
+		final RequestTemplate template = new RequestTemplate();
+		template.header(HttpEncoding.CONTENT_LENGTH, "2049");
+		template.header(HttpEncoding.CONTENT_TYPE, "application/json");
+		final FeignContentGzipEncodingInterceptor interceptor = new FeignContentGzipEncodingInterceptor(properties);
+
+		assertThatThrownBy(() -> interceptor.apply(template)).isInstanceOf(IllegalStateException.class)
+			.hasMessage("Invalid ContentEncodingTypes configuration");
+	}
+
+	@Test
+	void shouldThrowExceptionWhenNullContentEncodingTypes() {
+		final FeignClientEncodingProperties properties = new FeignClientEncodingProperties();
+		properties.setContentEncodingTypes(null);
+		final RequestTemplate template = new RequestTemplate();
+		template.header(HttpEncoding.CONTENT_LENGTH, "2049");
+		template.header(HttpEncoding.CONTENT_TYPE, "application/json");
+		final FeignContentGzipEncodingInterceptor interceptor = new FeignContentGzipEncodingInterceptor(properties);
+
+		assertThatThrownBy(() -> interceptor.apply(template)).isInstanceOf(IllegalStateException.class)
+			.hasMessage("Invalid ContentEncodingTypes configuration");
+	}
+
+}

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.2.0-RC1</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.2.0-RC1</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.2.0-M2</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.2.0-M2</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-M2</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-M2</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.2.1-SNAPSHOT</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.3.0-M1</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.3.0-M1</version>
+	<version>4.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.2.0</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.2.0</version>
+	<version>4.2.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.2.1-SNAPSHOT</version>
+	<version>4.3.0-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-RC1</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.0-RC1</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -10,7 +10,7 @@
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.2.0-SNAPSHOT</version>
+	<version>4.2.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -6,11 +6,11 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.0-M1</version>
 		<relativePath/>
 	</parent>
 	<artifactId>spring-cloud-openfeign-dependencies</artifactId>
-	<version>4.3.0-SNAPSHOT</version>
+	<version>4.3.0-M1</version>
 	<packaging>pom</packaging>
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-RC1</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-M2</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0-RC1</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.0</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-SNAPSHOT</version>
+		<version>4.2.1-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.3.0-M1</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.3.0-SNAPSHOT</version>
+		<version>4.3.0-M1</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.0-M2</version>
+		<version>4.2.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>

--- a/spring-cloud-starter-openfeign/pom.xml
+++ b/spring-cloud-starter-openfeign/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-openfeign</artifactId>
-		<version>4.2.1-SNAPSHOT</version>
+		<version>4.3.0-SNAPSHOT</version>
 		<relativePath>..</relativePath>
 	</parent>
 	<scm>


### PR DESCRIPTION
### Problem
When using the `@SpringQueryMap` annotation, it was difficult to discover the existence of the `QueryMapEncoder` class.  
The reference path is as follows:  
`@SpringQueryMap -> @QueryMap -> @Param Usage All`

Additionally, when using `@SpringQueryMap`, the default injected implementation is `FieldQueryMapEncoder`.  
However, in `FeignClientsConfiguration`, the injected bean can change depending on the `@ConditionalOnClass` condition.

```java
@Bean
@ConditionalOnClass(name = "org.springframework.data.domain.Pageable")
@ConditionalOnMissingBean
public QueryMapEncoder feignQueryMapEncoderPageable() {
	PageableSpringQueryMapEncoder queryMapEncoder = new PageableSpringQueryMapEncoder();
	if (springDataWebProperties != null) {
		queryMapEncoder.setPageParameter(springDataWebProperties.getPageable().getPageParameter());
		queryMapEncoder.setSizeParameter(springDataWebProperties.getPageable().getSizeParameter());
		queryMapEncoder.setSortParameter(springDataWebProperties.getSort().getSortParameter());
	}
	return queryMapEncoder;
}
```

Although `FieldQueryMapEncoder` is marked as **deprecated** in `QueryMapEncoder`, it still functions as the default implementation.

### Solution
I have explicitly specified this behavior in the annotation documentation.  
I encountered this issue while debugging, and it took me a long time to identify the cause.  
By adding this information, I hope others can find the relevant details more quickly.

### Consideration
I initially considered adding the note:  
> "The default implementation is `FieldQueryMapEncoder`, but it can change to `PageableSpringQueryMapEncoder` depending on the conditions."  

However, since this behavior is subject to change, I decided not to include it.  
If necessary, I am open to adding this detail.
