### PR TITLE
docs: Improve SpringQueryMap documentation

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/SpringQueryMap.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/SpringQueryMap.java
@@ -26,6 +26,8 @@ import java.lang.annotation.Target;
  *
  * @author Aram Peres
  * @see feign.QueryMap
+ * @see feign.QueryMapEncoder
+ * @see org.springframework.cloud.openfeign.FeignClientsConfiguration
  * @see org.springframework.cloud.openfeign.annotation.QueryMapParameterProcessor
  */
 @Retention(RetentionPolicy.RUNTIME)


### PR DESCRIPTION
### Problem
When using the `@SpringQueryMap` annotation, it was difficult to discover the existence of the `QueryMapEncoder` class.  
The reference path is as follows:  
`@SpringQueryMap -> @QueryMap -> @Param Usage All`

Additionally, when using `@SpringQueryMap`, the default injected implementation is `FieldQueryMapEncoder`.  
However, in `FeignClientsConfiguration`, the injected bean can change depending on the `@ConditionalOnClass` condition.

```java
@Bean
@ConditionalOnClass(name = "org.springframework.data.domain.Pageable")
@ConditionalOnMissingBean
public QueryMapEncoder feignQueryMapEncoderPageable() {
	PageableSpringQueryMapEncoder queryMapEncoder = new PageableSpringQueryMapEncoder();
	if (springDataWebProperties != null) {
		queryMapEncoder.setPageParameter(springDataWebProperties.getPageable().getPageParameter());
		queryMapEncoder.setSizeParameter(springDataWebProperties.getPageable().getSizeParameter());
		queryMapEncoder.setSortParameter(springDataWebProperties.getSort().getSortParameter());
	}
	return queryMapEncoder;
}
```

Although `FieldQueryMapEncoder` is marked as **deprecated** in `QueryMapEncoder`, it still functions as the default implementation.

### Solution
I have explicitly specified this behavior in the annotation documentation.  
I encountered this issue while debugging, and it took me a long time to identify the cause.  
By adding this information, I hope others can find the relevant details more quickly.

### Consideration
I initially considered adding the note:  
> "The default implementation is `FieldQueryMapEncoder`, but it can change to `PageableSpringQueryMapEncoder` depending on the conditions."  

However, since this behavior is subject to change, I decided not to include it.  
If necessary, I am open to adding this detail.

related to #1163
cc. @OlgaMaciaszek Thanks for your guidance!