### PR TITLE
feat: warn when GET method has unannotated parameters

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -240,12 +240,14 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 		MethodMetadata metadata = super.parseAndValidateMetadata(targetType, method);
 
 		if (isGetMethod(metadata) && method.getParameterCount() > 0 && !hasHttpAnnotations(method)) {
-			LOG.warn(String.format(
-				"[OpenFeign Warning] Feign method '%s' is declared as GET with parameters, but none of the parameters are annotated " +
-				"(e.g. @RequestParam, @RequestHeader, @PathVariable, etc). This may result in fallback to POST at runtime. " +
-				"Consider explicitly annotating parameters.",
-				method.toGenericString()
-			));
+			if (LOG.isWarnEnabled()) {
+				LOG.warn(String.format(
+					"[OpenFeign Warning] Feign method '%s' is declared as GET with parameters, but none of the parameters are annotated " +
+					"(e.g. @RequestParam, @RequestHeader, @PathVariable, etc). This may result in fallback to POST at runtime. " +
+					"Consider explicitly annotating parameters.",
+					method.toGenericString()
+				));
+			}
 		}
 
 		return metadata;


### PR DESCRIPTION
## Summary

This PR addresses issue [#1191](https://github.com/spring-cloud/spring-cloud-openfeign/issues/1191) by adding a warning when a `@FeignClient` method is declared as `GET` but has one or more parameters that are **not annotated** with any supported HTTP binding annotations (e.g., `@RequestParam`, `@RequestHeader`, `@PathVariable`, `@SpringQueryMap`, etc.).

## Context

When no annotations are present, Feign may attempt to treat those parameters as a request body. For `GET` methods, this leads to a body-less `POST` due to underlying HTTP client behavior (e.g., `HttpURLConnection`), which causes a discrepancy:

- The client logs show the request as `GET`
- The server receives the request as a `POST`
- No request body is actually sent (`Content-Length: 0`)

This is difficult to debug and confusing in real-world applications.

Related core issue: [OpenFeign/feign#2872](https://github.com/OpenFeign/feign/issues/2872)

## Implementation Details

- Added logic in `SpringMvcContract#parseAndValidateMetadata()` to check for:
  - Method is declared as `GET`
  - Method has parameters
  - None of the parameters have HTTP-related annotations
- If so, a warning is logged via SLF4J:
```java
[OpenFeign Warning] Feign method 'public abstract Response com.example.Client.getSomething(java.lang.String)' is declared as GET with parameters, but none of the parameters are annotated (e.g. @RequestParam, @RequestHeader, @PathVariable, etc). This may result in fallback to POST at runtime. Consider explicitly annotating parameters.
```
