### PR TITLE
Use ContentEncodingTypes from FeignClientEncodingProperties by default

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/encoding/FeignAcceptGzipEncodingInterceptor.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/encoding/FeignAcceptGzipEncodingInterceptor.java
@@ -43,8 +43,7 @@ public class FeignAcceptGzipEncodingInterceptor extends BaseRequestInterceptor {
 	@Override
 	public void apply(RequestTemplate template) {
 
-		addHeader(template, HttpEncoding.ACCEPT_ENCODING_HEADER, HttpEncoding.GZIP_ENCODING,
-				HttpEncoding.DEFLATE_ENCODING);
+		addHeader(template, HttpEncoding.ACCEPT_ENCODING_HEADER, getProperties().getContentEncodingTypes());
 	}
 
 }


### PR DESCRIPTION
Get ContentEncodingTypes from properties, instead of hardcoded.

Resolves #1249 