### PR TITLE
Updates for HttpMessageConverters changes in framework 7/boot 4.

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/FeignHttpMessageConverters.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/FeignHttpMessageConverters.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign.support;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.converter.HttpMessageConverters;
+import org.springframework.http.converter.StringHttpMessageConverter;
+
+/**
+ * Class that mimics {@link HttpMessageConverters} and the default implementation there.
+ * Applies the {@link HttpMessageConverterCustomizer}s and gathers all the converters into
+ * a {@link List}.
+ */
+public class FeignHttpMessageConverters {
+
+	private final ObjectProvider<HttpMessageConverter<?>> messageConverters;
+
+	private final ObjectProvider<HttpMessageConverterCustomizer> customizers;
+
+	private List<HttpMessageConverter<?>> converters;
+
+	public FeignHttpMessageConverters(ObjectProvider<HttpMessageConverter<?>> messageConverters,
+			ObjectProvider<HttpMessageConverterCustomizer> customizers) {
+		this.messageConverters = messageConverters;
+		this.customizers = customizers;
+	}
+
+	public List<HttpMessageConverter<?>> getConverters() {
+		initConvertersIfRequired();
+		return converters;
+	}
+
+	private void initConvertersIfRequired() {
+		if (this.converters == null) {
+			this.converters = new ArrayList<>();
+			HttpMessageConverters.ClientBuilder builder = HttpMessageConverters.forClient();
+			// TODO: allow disabling of registerDefaults
+			builder.registerDefaults();
+			// TODO: check if already added? Howto order?
+			this.messageConverters.forEach((converter) -> {
+				if (converter instanceof StringHttpMessageConverter) {
+					builder.withStringConverter(converter);
+				}
+				/*
+				 * else if (converter instanceof
+				 * KotlinSerializationJsonHttpMessageConverter) {
+				 * builder.withKotlinSerializationJsonConverter(converter); }
+				 */
+				else if (supportsMediaType(converter, MediaType.APPLICATION_JSON)) {
+					builder.withJsonConverter(converter);
+				}
+				else if (supportsMediaType(converter, MediaType.APPLICATION_XML)) {
+					builder.withXmlConverter(converter);
+				}
+				else {
+					builder.addCustomConverter(converter);
+				}
+			});
+			HttpMessageConverters hmc = builder.build();
+			hmc.forEach(converter -> converters.add(converter));
+			customizers.forEach(customizer -> customizer.accept(this.converters));
+		}
+	}
+
+	private static boolean supportsMediaType(HttpMessageConverter<?> converter, MediaType mediaType) {
+		for (MediaType supportedMediaType : converter.getSupportedMediaTypes()) {
+			if (supportedMediaType.equalsTypeAndSubtype(mediaType)) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/SpringDecoderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/SpringDecoderTests.java
@@ -22,13 +22,12 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.boot.http.converter.autoconfigure.HttpMessageConverters;
+import org.springframework.cloud.loadbalancer.support.SimpleObjectProvider;
+import org.springframework.cloud.openfeign.support.FeignHttpMessageConverters;
 import org.springframework.cloud.openfeign.support.SpringDecoder;
-import org.springframework.http.converter.HttpMessageConverter;
 
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for {@link SpringDecoder}.
@@ -41,9 +40,9 @@ class SpringDecoderTests {
 
 	@BeforeEach
 	void setUp() {
-		ObjectProvider<HttpMessageConverter<?>> factory = mock();
-		when(factory.orderedStream()).thenReturn(new HttpMessageConverters().getConverters().stream());
-		decoder = new SpringDecoder(factory);
+		ObjectProvider<FeignHttpMessageConverters> converters = new SimpleObjectProvider<>(
+				new FeignHttpMessageConverters(mock(), mock()));
+		decoder = new SpringDecoder(converters);
 	}
 
 	// Issue: https://github.com/spring-cloud/spring-cloud-openfeign/issues/972

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/proto/ProtobufNotInClasspathTest.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/encoding/proto/ProtobufNotInClasspathTest.java
@@ -22,6 +22,8 @@ import feign.RequestTemplate;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.cloud.loadbalancer.support.SimpleObjectProvider;
+import org.springframework.cloud.openfeign.support.FeignHttpMessageConverters;
 import org.springframework.cloud.openfeign.support.SpringEncoder;
 import org.springframework.cloud.test.ClassPathExclusions;
 import org.springframework.http.converter.HttpMessageConverter;
@@ -46,7 +48,8 @@ class ProtobufNotInClasspathTest {
 		when(factory.orderedStream()).thenReturn(protobufHttpMessageConverters.stream());
 		RequestTemplate requestTemplate = new RequestTemplate();
 		requestTemplate.method(POST);
-		new SpringEncoder(factory).encode("a=b", String.class, requestTemplate);
+		new SpringEncoder(new SimpleObjectProvider<>(new FeignHttpMessageConverters(factory, mock()))).encode("a=b",
+				String.class, requestTemplate);
 	}
 
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringEncoderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringEncoderTests.java
@@ -27,7 +27,6 @@ import feign.RequestTemplate;
 import feign.codec.EncodeException;
 import feign.codec.Encoder;
 import org.assertj.core.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -40,6 +39,7 @@ import org.springframework.cloud.openfeign.encoding.HttpEncoding;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpInputMessage;
@@ -100,14 +100,18 @@ class SpringEncoderTests {
 		encoder.encode("hi", MyType.class, request);
 
 		Collection<String> contentTypeHeader = request.headers().get("Content-Type");
-		assertThat(contentTypeHeader).as("missing content type header").isNotNull();
-		assertThat(contentTypeHeader.isEmpty()).as("missing content type header").isFalse();
+		assertThat(contentTypeHeader).as("missing content type header")
+			.isNotNull()
+			.as("missing content type header")
+			.isNotEmpty();
 
 		String header = contentTypeHeader.iterator().next();
 		assertThat(header).as("content type header is wrong").isEqualTo("application/mytype");
 
-		assertThat(request.requestCharset()).as("request charset is null").isNotNull();
-		assertThat(request.requestCharset()).as("request charset is wrong").isEqualTo(StandardCharsets.UTF_8);
+		assertThat(request.requestCharset()).as("request charset is null")
+			.isNotNull()
+			.as("request charset is wrong")
+			.isEqualTo(StandardCharsets.UTF_8);
 	}
 
 	// gh-225
@@ -124,17 +128,20 @@ class SpringEncoderTests {
 		encoder.encode(Collections.singletonList("hi"), stringListType.getType(), request);
 
 		Collection<String> contentTypeHeader = request.headers().get("Content-Type");
-		assertThat(contentTypeHeader).as("missing content type header").isNotNull();
-		assertThat(contentTypeHeader.isEmpty()).as("missing content type header").isFalse();
+		assertThat(contentTypeHeader).as("missing content type header")
+			.isNotNull()
+			.as("missing content type header")
+			.isNotEmpty();
 
 		String header = contentTypeHeader.iterator().next();
 		assertThat(header).as("content type header is wrong").isEqualTo("application/mygenerictype");
 
-		assertThat(request.requestCharset()).as("request charset is null").isNotNull();
-		assertThat(request.requestCharset()).as("request charset is wrong").isEqualTo(StandardCharsets.UTF_8);
+		assertThat(request.requestCharset()).as("request charset is null")
+			.isNotNull()
+			.as("request charset is wrong")
+			.isEqualTo(StandardCharsets.UTF_8);
 	}
 
-	@Disabled("FIXME: https://github.com/spring-cloud/spring-cloud-openfeign/issues/1269")
 	@Test
 	void testBinaryData() {
 		Encoder encoder = this.context.getInstance("foo", Encoder.class);
@@ -175,8 +182,8 @@ class SpringEncoderTests {
 		assertThat((String) ((List) request.headers().get(CONTENT_TYPE)).get(0))
 			.as("Request Content-Type is not multipart/form-data")
 			.contains("multipart/form-data; charset=UTF-8; boundary=");
-		assertThat(request.headers().get(CONTENT_TYPE).size()).as("There is more than one Content-Type request header")
-			.isEqualTo(1);
+		assertThat(request.headers().get(CONTENT_TYPE)).as("There is more than one Content-Type request header")
+			.hasSize(1);
 		assertThat(((List) request.headers().get(ACCEPT)).get(0)).as("Request Accept header is not multipart/form-data")
 			.isEqualTo(MULTIPART_FORM_DATA_VALUE);
 		assertThat(((List) request.headers().get(CONTENT_LENGTH)).get(0))
@@ -260,10 +267,16 @@ class SpringEncoderTests {
 			return new MyGenericHttpMessageConverter();
 		}
 
-		private static class MyHttpMessageConverter extends AbstractGenericHttpMessageConverter<Object> {
+		private static class MyHttpMessageConverter extends AbstractGenericHttpMessageConverter<Object>
+				implements Ordered {
 
 			MyHttpMessageConverter() {
 				super(new MediaType("application", "mytype"));
+			}
+
+			@Override
+			public int getOrder() {
+				return Ordered.HIGHEST_PRECEDENCE;
 			}
 
 			@Override


### PR DESCRIPTION
Since HttpMessageConverter instances are no longer registered as beans, moved to a new strategy backed by FeignHttpMessageConverters which is mostly copied from boot.

Fixes gh-1269