### PR TITLE
Fix incorrect HttpHeaders handling in RequestHeaderParameterProcessor

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/RequestHeaderParameterProcessor.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/annotation/RequestHeaderParameterProcessor.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import feign.MethodMetadata;
 
 import org.springframework.cloud.openfeign.AnnotatedParameterProcessor;
+import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 import static feign.Util.checkState;
@@ -51,7 +52,7 @@ public class RequestHeaderParameterProcessor implements AnnotatedParameterProces
 		Class<?> parameterType = method.getParameterTypes()[parameterIndex];
 		MethodMetadata data = context.getMethodMetadata();
 
-		if (Map.class.isAssignableFrom(parameterType)) {
+		if (Map.class.isAssignableFrom(parameterType) || HttpHeaders.class.isAssignableFrom(parameterType)) {
 			checkState(data.headerMapIndex() == null, "Header map can only be present once.");
 			data.headerMapIndex(parameterIndex);
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
@@ -45,6 +45,7 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.format.annotation.NumberFormat;
 import org.springframework.format.number.NumberStyleFormatter;
 import org.springframework.format.support.FormattingConversionServiceFactoryBean;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.MultiValueMap;
@@ -643,6 +644,17 @@ class SpringMvcContractTests {
 	}
 
 	@Test
+	void testProcessHttpHeaders() throws Exception {
+		Method method = TestTemplate_HeaderMap.class.getDeclaredMethod("httpHeaders", HttpHeaders.class);
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().url()).isEqualTo("/httpHeaders");
+		assertThat(data.template().method()).isEqualTo("GET");
+		assertThat(data.headerMapIndex()).isNotNull();
+		assertThat(data.headerMapIndex().intValue()).isEqualTo(0);
+	}
+
+	@Test
 	void testProcessHeaderMapMoreThanOnce() throws Exception {
 		Method method = TestTemplate_HeaderMap.class.getDeclaredMethod("headerMapMoreThanOnce", MultiValueMap.class,
 				MultiValueMap.class);
@@ -912,6 +924,9 @@ class SpringMvcContractTests {
 		@GetMapping("/headerMap")
 		String headerMap(@RequestHeader MultiValueMap<String, String> headerMap,
 				@RequestHeader(name = "aHeader") String aHeader);
+
+		@GetMapping("/httpHeaders")
+		String httpHeaders(@RequestHeader HttpHeaders headers);
 
 		@GetMapping("/headerMapMoreThanOnce")
 		String headerMapMoreThanOnce(@RequestHeader MultiValueMap<String, String> headerMap1,


### PR DESCRIPTION
In Spring 4, HttpHeaders no longer implements the Map interface, which makes the comparison in RequestHeaderParameterProcessor invalid. This PR addresses this issue.