### PR TITLE
Fix #1270: Support dash-case for oauth2.clientRegistrationId

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
@@ -100,11 +100,12 @@ import org.springframework.util.ClassUtils;
  * @author Wojciech Mąka
  * @author Dangzhicairang(小水牛)
  * @author changjin wei(魏昌进)
+ * @author jaehun lee
  */
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(Feign.class)
 @EnableConfigurationProperties({ FeignClientProperties.class, FeignHttpClientProperties.class,
-		FeignEncoderProperties.class })
+		FeignEncoderProperties.class, FeignOAuth2Properties.class })
 public class FeignAutoConfiguration {
 
 	private static final Log LOG = LogFactory.getLog(FeignAutoConfiguration.class);
@@ -392,10 +393,10 @@ public class FeignAutoConfiguration {
 
 		@Bean
 		@ConditionalOnBean(OAuth2AuthorizedClientManager.class)
-		public OAuth2AccessTokenInterceptor defaultOAuth2AccessTokenInterceptor(
-				@Value("${spring.cloud.openfeign.oauth2.clientRegistrationId:}") String clientRegistrationId,
+		public OAuth2AccessTokenInterceptor defaultOAuth2AccessTokenInterceptor(FeignOAuth2Properties oAuth2Properties,
 				OAuth2AuthorizedClientManager oAuth2AuthorizedClientManager) {
-			return new OAuth2AccessTokenInterceptor(clientRegistrationId, oAuth2AuthorizedClientManager);
+			return new OAuth2AccessTokenInterceptor(oAuth2Properties.getClientRegistrationId(),
+					oAuth2AuthorizedClientManager);
 		}
 
 	}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignOAuth2Properties.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignOAuth2Properties.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Feign OAuth2 support.
+ *
+ * @author jaehun lee
+ */
+@ConfigurationProperties(prefix = "spring.cloud.openfeign.oauth2")
+public class FeignOAuth2Properties {
+
+	/**
+	 * Enables feign interceptor for managing oauth2 access token.
+	 */
+	private boolean enabled = false;
+
+	/**
+	 * Client registration id to be used to retrieve the OAuth2 access token. If not
+	 * specified, the {@code serviceId} retrieved from the {@code url} host segment will
+	 * be used. This is convenient for load-balanced Feign clients. For non-load-balanced
+	 * clients, specifying the {@code clientRegistrationId} is recommended.
+	 */
+	private String clientRegistrationId = "";
+
+	public boolean isEnabled() {
+		return enabled;
+	}
+
+	public void setEnabled(boolean enabled) {
+		this.enabled = enabled;
+	}
+
+	public String getClientRegistrationId() {
+		return clientRegistrationId;
+	}
+
+	public void setClientRegistrationId(String clientRegistrationId) {
+		this.clientRegistrationId = clientRegistrationId;
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
@@ -42,6 +42,7 @@ import static org.mockito.Mockito.mock;
  * @author Kwangyong Kim
  * @author Wojciech Mąka
  * @author Dangzhicairang(小水牛)
+ * @author jaehun lee
  */
 class FeignAutoConfigurationTests {
 
@@ -95,6 +96,19 @@ class FeignAutoConfigurationTests {
 		runner
 			.withPropertyValues("spring.cloud.openfeign.oauth2.enabled=true",
 					"spring.cloud.openfeign.oauth2.clientRegistrationId=feign-client")
+			.withBean(OAuth2AuthorizedClientService.class, () -> mock(OAuth2AuthorizedClientService.class))
+			.withBean(ClientRegistrationRepository.class, () -> mock(ClientRegistrationRepository.class))
+			.run(ctx -> {
+				assertOauth2AccessTokenInterceptorExists(ctx);
+				assertThatOauth2AccessTokenInterceptorHasSpecifiedIdsPropertyWithValue(ctx, "feign-client");
+			});
+	}
+
+	@Test
+	void shouldInstantiateFeignOAuth2FeignRequestInterceptorWithDashCaseProperty() {
+		runner
+			.withPropertyValues("spring.cloud.openfeign.oauth2.enabled=true",
+					"spring.cloud.openfeign.oauth2.client-registration-id=feign-client")
 			.withBean(OAuth2AuthorizedClientService.class, () -> mock(OAuth2AuthorizedClientService.class))
 			.withBean(ClientRegistrationRepository.class, () -> mock(ClientRegistrationRepository.class))
 			.run(ctx -> {


### PR DESCRIPTION
## Description

This PR fixes #1270 by adding support for dash-case (kebab-case) property binding for `spring.cloud.openfeign.oauth2.clientRegistrationId`.

Currently, the OAuth2 configuration only accepts camelCase format (`clientRegistrationId`), which is inconsistent with other Spring Boot properties that support relaxed binding (dash-case, snake_case, etc.).

## Changes

- Created `FeignOAuth2Properties` class with `@ConfigurationProperties` annotation
- Replaced `@Value` injection with `FeignOAuth2Properties` in `FeignAutoConfiguration`
- Enabled relaxed binding for OAuth2 configuration properties

## Behavior

### Before
spring:
  cloud:
    openfeign:
      oauth2:
        clientRegistrationId: fancy      # ✅ Works
        client-registration-id: fancy    # ❌ Does not work