### PR TITLE
Update io.github.openfeign:feign-bom to 13.8

### DIFF
--- a/spring-cloud-openfeign-dependencies/pom.xml
+++ b/spring-cloud-openfeign-dependencies/pom.xml
@@ -15,7 +15,7 @@
 	<name>spring-cloud-openfeign-dependencies</name>
 	<description>Spring Cloud OpenFeign Dependencies</description>
 	<properties>
-		<feign.version>13.6</feign.version>
+		<feign.version>13.8</feign.version>
 	</properties>
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
Fixes #1221
Fixes #1260 

Updates to the latest release 13.8 of OpenFeign to fix the common-filupload CVE