### PR TITLE
Fix #1324: Add @JsonAlias support to SimplePageable for SNAKE_CASE compatibility

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageJacksonModule.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageJacksonModule.java
@@ -242,8 +242,10 @@ public class PageJacksonModule extends Module {
 
 		private final PageRequest delegate;
 
-		SimplePageable(@JsonProperty("pageNumber") int number, @JsonProperty("pageSize") int size,
-				@JsonProperty("sort") Sort sort) {
+		SimplePageable(
+			@JsonProperty("pageNumber") @JsonAlias({"page-number", "page_number", "pagenumber", "PageNumber"}) int number,
+			@JsonProperty("pageSize") @JsonAlias({"page-size", "page_size", "pagesize", "PageSize"}) int size,
+			@JsonProperty("sort") Sort sort) {
 			delegate = buildPageRequest(number, size, sort);
 		}
 

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageJacksonModule.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageJacksonModule.java
@@ -243,9 +243,10 @@ public class PageJacksonModule extends Module {
 		private final PageRequest delegate;
 
 		SimplePageable(
-			@JsonProperty("pageNumber") @JsonAlias({"page-number", "page_number", "pagenumber", "PageNumber"}) int number,
-			@JsonProperty("pageSize") @JsonAlias({"page-size", "page_size", "pagesize", "PageSize"}) int size,
-			@JsonProperty("sort") Sort sort) {
+				@JsonProperty("pageNumber") @JsonAlias({ "page-number", "page_number", "pagenumber",
+						"PageNumber" }) int number,
+				@JsonProperty("pageSize") @JsonAlias({ "page-size", "page_size", "pagesize", "PageSize" }) int size,
+				@JsonProperty("sort") Sort sort) {
 			delegate = buildPageRequest(number, size, sort);
 		}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageJacksonModuleTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageJacksonModuleTests.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -186,6 +187,85 @@ class PageJacksonModuleTests {
 		assertThat(cascadedResult.getContent().get(1)).isEqualTo("second element in cascaded serialization");
 		assertThat(cascadedResult.getPageable().getPageSize()).isEqualTo(2);
 		assertThat(cascadedResult.getPageable().getPageNumber()).isEqualTo(6);
+	}
+
+	@Test
+	void deserializePageableWithHyphenatedAlias() throws IOException {
+		// Given
+		ObjectMapper snakeCaseMapper = objectMapper.copy();
+		snakeCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
+		File file = new File("./src/test/resources/withPageableAliasHyphen.json");
+		// When
+		Page<?> result = objectMapper.readValue(file, Page.class);
+		// Then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalElements()).isEqualTo(15);
+		assertThat(result.getContent()).hasSize(10);
+		assertThat(result.getPageable()).isNotNull();
+		assertThat(result.getPageable().getPageNumber()).isEqualTo(2);
+		assertThat(result.getPageable().getPageSize()).isEqualTo(3);
+		assertThat(result.getPageable().getSort().getOrderFor("firstName").getDirection())
+			.isEqualTo(Sort.Direction.ASC);
+	}
+
+	@Test
+	void deserializePageableWithUnderscoreAlias() throws IOException {
+		// Given
+		ObjectMapper snakeCaseMapper = objectMapper.copy();
+		snakeCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+		File file = new File("./src/test/resources/withPageableAliasUnderscore.json");
+
+		// When
+		Page<?> result = snakeCaseMapper.readValue(file, Page.class);
+		// Then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalElements()).isEqualTo(10);
+		assertThat(result.getContent()).hasSize(10);
+		assertThat(result.getPageable()).isNotNull();
+		assertThat(result.getPageable().getPageNumber()).isEqualTo(1);
+		assertThat(result.getPageable().getPageSize()).isEqualTo(2);
+		assertThat(result.getPageable().getSort().getOrderFor("lastName").getDirection())
+			.isEqualTo(Sort.Direction.DESC);
+	}
+
+	@Test
+	void deserializePageableWithLowercaseAlias() throws IOException {
+		// Given
+		ObjectMapper snakeCaseMapper = objectMapper.copy();
+		snakeCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CASE);
+
+		File file = new File("./src/test/resources/withPageableAliasLowercase.json");
+
+		// When
+		Page<?> result = objectMapper.readValue(file, Page.class);
+		// Then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalElements()).isEqualTo(8);
+		assertThat(result.getContent()).hasSize(10);
+		assertThat(result.getPageable()).isNotNull();
+		assertThat(result.getPageable().getPageNumber()).isEqualTo(0);
+		assertThat(result.getPageable().getPageSize()).isEqualTo(4);
+		assertThat(result.getPageable().getSort()).isEqualTo(Sort.unsorted());
+	}
+
+	@Test
+	void deserializePageableWithPascalCaseAlias() throws IOException {
+		// Given
+		ObjectMapper snakeCaseMapper = objectMapper.copy();
+		snakeCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
+		File file = new File("./src/test/resources/withPageableAliasPascalCase.json");
+
+		// When
+		Page<?> result = objectMapper.readValue(file, Page.class);
+		// Then
+		assertThat(result).isNotNull();
+		assertThat(result.getTotalElements()).isEqualTo(20);
+		assertThat(result.getContent()).hasSize(10);
+		assertThat(result.getPageable()).isNotNull();
+		assertThat(result.getPageable().getPageNumber()).isEqualTo(3);
+		assertThat(result.getPageable().getPageSize()).isEqualTo(2);
+		assertThat(result.getPageable().getSort().getOrderFor("firstName").getDirection())
+			.isEqualTo(Sort.Direction.ASC);
 	}
 
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageJacksonModuleTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageJacksonModuleTests.java
@@ -192,11 +192,11 @@ class PageJacksonModuleTests {
 	@Test
 	void deserializePageableWithHyphenatedAlias() throws IOException {
 		// Given
-		ObjectMapper kebabOjectMapepr = objectMapper.copy();
-		kebabOjectMapepr.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
+		ObjectMapper kebabObjectMapepr = objectMapper.copy();
+		kebabObjectMapepr.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
 		File file = new File("./src/test/resources/withPageableAliasHyphen.json");
 		// When
-		Page<?> result = kebabOjectMapepr.readValue(file, Page.class);
+		Page<?> result = kebabObjectMapepr.readValue(file, Page.class);
 		// Then
 		assertThat(result).isNotNull();
 		assertThat(result.getTotalElements()).isEqualTo(15);
@@ -211,12 +211,12 @@ class PageJacksonModuleTests {
 	@Test
 	void deserializePageableWithUnderscoreAlias() throws IOException {
 		// Given
-		ObjectMapper snakeCaseMapper = objectMapper.copy();
-		snakeCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
+		ObjectMapper snakeCaseObjectMapper = objectMapper.copy();
+		snakeCaseObjectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 		File file = new File("./src/test/resources/withPageableAliasUnderscore.json");
 
 		// When
-		Page<?> result = snakeCaseMapper.readValue(file, Page.class);
+		Page<?> result = snakeCaseObjectMapper.readValue(file, Page.class);
 		// Then
 		assertThat(result).isNotNull();
 		assertThat(result.getTotalElements()).isEqualTo(10);
@@ -231,13 +231,13 @@ class PageJacksonModuleTests {
 	@Test
 	void deserializePageableWithLowercaseAlias() throws IOException {
 		// Given
-		ObjectMapper lowerCaseMapper = objectMapper.copy();
-		lowerCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CASE);
+		ObjectMapper lowerCaseObjectMapper = objectMapper.copy();
+		lowerCaseObjectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CASE);
 
 		File file = new File("./src/test/resources/withPageableAliasLowercase.json");
 
 		// When
-		Page<?> result = lowerCaseMapper.readValue(file, Page.class);
+		Page<?> result = lowerCaseObjectMapper.readValue(file, Page.class);
 		// Then
 		assertThat(result).isNotNull();
 		assertThat(result.getTotalElements()).isEqualTo(8);
@@ -251,12 +251,12 @@ class PageJacksonModuleTests {
 	@Test
 	void deserializePageableWithPascalCaseAlias() throws IOException {
 		// Given
-		ObjectMapper upperCamelCaseMapper = objectMapper.copy();
-		upperCamelCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
+		ObjectMapper upperCamelCaseObjectMapper = objectMapper.copy();
+		upperCamelCaseObjectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
 		File file = new File("./src/test/resources/withPageableAliasPascalCase.json");
 
 		// When
-		Page<?> result = upperCamelCaseMapper.readValue(file, Page.class);
+		Page<?> result = upperCamelCaseObjectMapper.readValue(file, Page.class);
 		// Then
 		assertThat(result).isNotNull();
 		assertThat(result.getTotalElements()).isEqualTo(20);

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageJacksonModuleTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageJacksonModuleTests.java
@@ -192,11 +192,11 @@ class PageJacksonModuleTests {
 	@Test
 	void deserializePageableWithHyphenatedAlias() throws IOException {
 		// Given
-		ObjectMapper snakeCaseMapper = objectMapper.copy();
-		snakeCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
+		ObjectMapper kebabOjectMapepr = objectMapper.copy();
+		kebabOjectMapepr.setPropertyNamingStrategy(PropertyNamingStrategies.KEBAB_CASE);
 		File file = new File("./src/test/resources/withPageableAliasHyphen.json");
 		// When
-		Page<?> result = objectMapper.readValue(file, Page.class);
+		Page<?> result = kebabOjectMapepr.readValue(file, Page.class);
 		// Then
 		assertThat(result).isNotNull();
 		assertThat(result.getTotalElements()).isEqualTo(15);
@@ -231,13 +231,13 @@ class PageJacksonModuleTests {
 	@Test
 	void deserializePageableWithLowercaseAlias() throws IOException {
 		// Given
-		ObjectMapper snakeCaseMapper = objectMapper.copy();
-		snakeCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CASE);
+		ObjectMapper lowerCaseMapper = objectMapper.copy();
+		lowerCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CASE);
 
 		File file = new File("./src/test/resources/withPageableAliasLowercase.json");
 
 		// When
-		Page<?> result = objectMapper.readValue(file, Page.class);
+		Page<?> result = lowerCaseMapper.readValue(file, Page.class);
 		// Then
 		assertThat(result).isNotNull();
 		assertThat(result.getTotalElements()).isEqualTo(8);
@@ -251,12 +251,12 @@ class PageJacksonModuleTests {
 	@Test
 	void deserializePageableWithPascalCaseAlias() throws IOException {
 		// Given
-		ObjectMapper snakeCaseMapper = objectMapper.copy();
-		snakeCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
+		ObjectMapper upperCamelCaseMapper = objectMapper.copy();
+		upperCamelCaseMapper.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
 		File file = new File("./src/test/resources/withPageableAliasPascalCase.json");
 
 		// When
-		Page<?> result = objectMapper.readValue(file, Page.class);
+		Page<?> result = upperCamelCaseMapper.readValue(file, Page.class);
 		// Then
 		assertThat(result).isNotNull();
 		assertThat(result.getTotalElements()).isEqualTo(20);

--- a/spring-cloud-openfeign-core/src/test/resources/withPageableAliasHyphen.json
+++ b/spring-cloud-openfeign-core/src/test/resources/withPageableAliasHyphen.json
@@ -1,0 +1,77 @@
+{
+	"content": [
+		{
+			"id": 3,
+			"lastName": "Williams",
+			"firstName": "Thomas",
+			"email": "w.t@my.domain.com"
+		},
+		{
+			"id": 1,
+			"lastName": "Smith",
+			"firstName": "James",
+			"email": "s.j@my.domain.com"
+		},
+		{
+			"id": 11,
+			"lastName": "Scott",
+			"firstName": "Steven",
+			"email": "s.s@my.domain.com"
+		},
+		{
+			"id": 8,
+			"lastName": "Rodriguez",
+			"firstName": "Daniel",
+			"email": "r.d@my.domain.com"
+		},
+		{
+			"id": 9,
+			"lastName": "Martinez",
+			"firstName": "Robert",
+			"email": "m.r@my.domain.com"
+		},
+		{
+			"id": 5,
+			"lastName": "Jones",
+			"firstName": "James",
+			"email": "j.j@my.domain.com"
+		},
+		{
+			"id": 2,
+			"lastName": "Johnson",
+			"firstName": "Robert",
+			"email": "j.r@my.domain.com"
+		},
+		{
+			"id": 6,
+			"lastName": "Garcia",
+			"firstName": "William",
+			"email": "g.w@my.domain.com"
+		},
+		{
+			"id": 7,
+			"lastName": "Davis",
+			"firstName": "Richard",
+			"email": "d.r@my.domain.com"
+		},
+		{
+			"id": 4,
+			"lastName": "Brown",
+			"firstName": "Paul",
+			"email": "b.p@my.domain.com"
+		}
+	],
+	"pageable": {
+		"page-number": 2,
+		"page-size": 3,
+		"sort": {
+			"orders": [
+				{
+					"direction": "ASC",
+					"property": "firstName"
+				}
+			]
+		}
+	},
+	"totalElements": 15
+}

--- a/spring-cloud-openfeign-core/src/test/resources/withPageableAliasLowercase.json
+++ b/spring-cloud-openfeign-core/src/test/resources/withPageableAliasLowercase.json
@@ -1,0 +1,72 @@
+{
+	"content": [
+		{
+			"id": 3,
+			"lastName": "Williams",
+			"firstName": "Thomas",
+			"email": "w.t@my.domain.com"
+		},
+		{
+			"id": 1,
+			"lastName": "Smith",
+			"firstName": "James",
+			"email": "s.j@my.domain.com"
+		},
+		{
+			"id": 11,
+			"lastName": "Scott",
+			"firstName": "Steven",
+			"email": "s.s@my.domain.com"
+		},
+		{
+			"id": 8,
+			"lastName": "Rodriguez",
+			"firstName": "Daniel",
+			"email": "r.d@my.domain.com"
+		},
+		{
+			"id": 9,
+			"lastName": "Martinez",
+			"firstName": "Robert",
+			"email": "m.r@my.domain.com"
+		},
+		{
+			"id": 5,
+			"lastName": "Jones",
+			"firstName": "James",
+			"email": "j.j@my.domain.com"
+		},
+		{
+			"id": 2,
+			"lastName": "Johnson",
+			"firstName": "Robert",
+			"email": "j.r@my.domain.com"
+		},
+		{
+			"id": 6,
+			"lastName": "Garcia",
+			"firstName": "William",
+			"email": "g.w@my.domain.com"
+		},
+		{
+			"id": 7,
+			"lastName": "Davis",
+			"firstName": "Richard",
+			"email": "d.r@my.domain.com"
+		},
+		{
+			"id": 4,
+			"lastName": "Brown",
+			"firstName": "Paul",
+			"email": "b.p@my.domain.com"
+		}
+	],
+	"pageable": {
+		"pagenumber": 0,
+		"pagesize": 4,
+		"sort": {
+			"orders": []
+		}
+	},
+	"totalElements": 8
+}

--- a/spring-cloud-openfeign-core/src/test/resources/withPageableAliasPascalCase.json
+++ b/spring-cloud-openfeign-core/src/test/resources/withPageableAliasPascalCase.json
@@ -1,0 +1,77 @@
+{
+	"content": [
+		{
+			"id": 3,
+			"lastName": "Williams",
+			"firstName": "Thomas",
+			"email": "w.t@my.domain.com"
+		},
+		{
+			"id": 1,
+			"lastName": "Smith",
+			"firstName": "James",
+			"email": "s.j@my.domain.com"
+		},
+		{
+			"id": 11,
+			"lastName": "Scott",
+			"firstName": "Steven",
+			"email": "s.s@my.domain.com"
+		},
+		{
+			"id": 8,
+			"lastName": "Rodriguez",
+			"firstName": "Daniel",
+			"email": "r.d@my.domain.com"
+		},
+		{
+			"id": 9,
+			"lastName": "Martinez",
+			"firstName": "Robert",
+			"email": "m.r@my.domain.com"
+		},
+		{
+			"id": 5,
+			"lastName": "Jones",
+			"firstName": "James",
+			"email": "j.j@my.domain.com"
+		},
+		{
+			"id": 2,
+			"lastName": "Johnson",
+			"firstName": "Robert",
+			"email": "j.r@my.domain.com"
+		},
+		{
+			"id": 6,
+			"lastName": "Garcia",
+			"firstName": "William",
+			"email": "g.w@my.domain.com"
+		},
+		{
+			"id": 7,
+			"lastName": "Davis",
+			"firstName": "Richard",
+			"email": "d.r@my.domain.com"
+		},
+		{
+			"id": 4,
+			"lastName": "Brown",
+			"firstName": "Paul",
+			"email": "b.p@my.domain.com"
+		}
+	],
+	"pageable": {
+		"PageNumber": 3,
+		"PageSize": 2,
+		"sort": {
+			"orders": [
+				{
+					"direction": "ASC",
+					"property": "firstName"
+				}
+			]
+		}
+	},
+	"totalElements": 20
+}

--- a/spring-cloud-openfeign-core/src/test/resources/withPageableAliasUnderscore.json
+++ b/spring-cloud-openfeign-core/src/test/resources/withPageableAliasUnderscore.json
@@ -1,0 +1,77 @@
+{
+	"content": [
+		{
+			"id": 3,
+			"lastName": "Williams",
+			"firstName": "Thomas",
+			"email": "w.t@my.domain.com"
+		},
+		{
+			"id": 1,
+			"lastName": "Smith",
+			"firstName": "James",
+			"email": "s.j@my.domain.com"
+		},
+		{
+			"id": 11,
+			"lastName": "Scott",
+			"firstName": "Steven",
+			"email": "s.s@my.domain.com"
+		},
+		{
+			"id": 8,
+			"lastName": "Rodriguez",
+			"firstName": "Daniel",
+			"email": "r.d@my.domain.com"
+		},
+		{
+			"id": 9,
+			"lastName": "Martinez",
+			"firstName": "Robert",
+			"email": "m.r@my.domain.com"
+		},
+		{
+			"id": 5,
+			"lastName": "Jones",
+			"firstName": "James",
+			"email": "j.j@my.domain.com"
+		},
+		{
+			"id": 2,
+			"lastName": "Johnson",
+			"firstName": "Robert",
+			"email": "j.r@my.domain.com"
+		},
+		{
+			"id": 6,
+			"lastName": "Garcia",
+			"firstName": "William",
+			"email": "g.w@my.domain.com"
+		},
+		{
+			"id": 7,
+			"lastName": "Davis",
+			"firstName": "Richard",
+			"email": "d.r@my.domain.com"
+		},
+		{
+			"id": 4,
+			"lastName": "Brown",
+			"firstName": "Paul",
+			"email": "b.p@my.domain.com"
+		}
+	],
+	"pageable": {
+		"page_number": 1,
+		"page_size": 2,
+		"sort": {
+			"orders": [
+				{
+					"direction": "DESC",
+					"property": "lastName"
+				}
+			]
+		}
+	},
+	"totalElements": 10
+}


### PR DESCRIPTION
Fixes #1324

When a global PropertyNamingStrategies.SNAKE_CASE is configured, deserialization of Page fails because SimplePageable only accepted camelCase property names.

This PR adds @JsonProperty + @JsonAlias to the constructor parameters, supporting:

pageNumber / page_number / page-number / pagenumber
pageSize / page_size / page-size / pagesize
Tested with the reproduction case provided in the issue (global SNAKE_CASE + WireMock returning snake_case JSON).