### PR TITLE
Fix issue#1198 HTTP connection leak when using feign.Response with chunked Transfer-Encoding

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -23,7 +23,10 @@ import feign.Contract;
 import feign.Feign;
 import feign.Logger;
 import feign.QueryMapEncoder;
+import feign.Response;
+import feign.ResponseInterceptor;
 import feign.Retryer;
+import feign.Util;
 import feign.codec.Decoder;
 import feign.codec.Encoder;
 import feign.form.MultipartFormContentProcessor;
@@ -110,6 +113,21 @@ public class FeignClientsConfiguration {
 	@ConditionalOnMissingBean
 	public Decoder feignDecoder(ObjectProvider<FeignHttpMessageConverters> messageConverters) {
 		return new OptionalDecoder(new ResponseEntityDecoder(new SpringDecoder(messageConverters)));
+	}
+
+	@Bean
+	@ConditionalOnMissingBean
+	public ResponseInterceptor feignResponseInterceptor() {
+		return (invocationContext, chain) -> {
+			Response response = chain.next(invocationContext);
+			if (invocationContext.returnType() == Response.class && response.body() != null
+					&& response.body().length() == null) {
+				byte[] bodyData = Util.toByteArray(response.body().asInputStream());
+				response.close();
+				return response.toBuilder().body(bodyData).build();
+			}
+			return response;
+		};
 	}
 
 	@Bean


### PR DESCRIPTION
### Summary
Close https://github.com/spring-cloud/spring-cloud-openfeign/issues/1198. When a @FeignClient method declares feign.Response as its return type and the server responds with Transfer-Encoding: chunked, the underlying HTTP connection is never released back to the connection pool, causing a connection leak.

### Root Cause
Feign-core's InvocationContext.proceed() has a special path for feign.Response return type — it bypasses the entire decoder chain and calls disconnectResponseBodyIfNeeded(). This method only buffers the response body when body.length() != null && body.length() <= 8192. 

For chunked responses, body.length() returns null (content length is unknown), so the buffering is skipped and the raw Response with a live InputStream tied to the pooled HTTP connection is returned directly to the caller. If the caller does not explicitly close the Response, the connection is permanently leaked.

### Fix
Register a default ResponseInterceptor bean in FeignClientsConfiguration that intercepts the response before it reaches feign-core's disconnectResponseBodyIfNeeded(). 
When the return type is feign.Response and the body has unknown length (chunked), the interceptor:
1. Buffers the body into a byte[]
2. Closes the original response (releasing the HTTP connection)
3. Rebuilds the response with the in-memory body