### PR TITLE
Fix #916: Include all produces values in Accept header

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -30,6 +30,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import feign.Contract;
 import feign.Feign;
@@ -93,6 +94,7 @@ import static org.springframework.core.annotation.AnnotatedElementUtils.findMerg
  * @author Sam Kruglov
  * @author Tang Xiong
  * @author Juhyeong An
+ * @author Olof Segergren
  */
 public class SpringMvcContract extends Contract.BaseContract implements ResourceLoaderAware {
 
@@ -417,9 +419,11 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 	}
 
 	private void parseProduces(MethodMetadata md, RequestMapping annotation) {
-		String[] serverProduces = annotation.produces();
-		String clientAccepts = serverProduces.length == 0 ? null : emptyToNull(serverProduces[0]);
-		if (clientAccepts != null) {
+		String clientAccepts = Arrays.stream(annotation.produces())
+			.map(s -> emptyToNull(s))
+			.filter(Objects::nonNull)
+			.collect(Collectors.joining(", "));
+		if (StringUtils.hasText(clientAccepts)) {
 			md.template().header(ACCEPT, clientAccepts);
 		}
 	}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -30,7 +30,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import feign.Contract;
 import feign.Feign;
@@ -419,11 +418,11 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 	}
 
 	private void parseProduces(MethodMetadata md, RequestMapping annotation) {
-		String clientAccepts = Arrays.stream(annotation.produces())
+		String[] clientAccepts = Arrays.stream(annotation.produces())
 			.map(s -> emptyToNull(s))
 			.filter(Objects::nonNull)
-			.collect(Collectors.joining(", "));
-		if (StringUtils.hasText(clientAccepts)) {
+			.toArray(String[]::new);
+		if (clientAccepts.length > 0) {
 			md.template().header(ACCEPT, clientAccepts);
 		}
 	}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
@@ -769,7 +769,7 @@ class SpringMvcContractTests {
 		Method method = TestTemplate_MultipleProduces.class.getDeclaredMethod("multipleProduces");
 		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
 
-		assertThat(data.template().headers().get("Accept")).containsExactly("application/jose, application/json");
+		assertThat(data.template().headers().get("Accept")).containsExactly("application/jose", "application/json");
 	}
 
 	@Test
@@ -793,7 +793,7 @@ class SpringMvcContractTests {
 		Method method = TestTemplate_MultipleProduces.class.getDeclaredMethod("producesWithBlankEntry");
 		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
 
-		assertThat(data.template().headers().get("Accept")).containsExactly("application/jose, application/json");
+		assertThat(data.template().headers().get("Accept")).containsExactly("application/jose", "application/json");
 	}
 
 	@Test

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
@@ -765,6 +765,38 @@ class SpringMvcContractTests {
 	}
 
 	@Test
+	void testMultipleProducesValues() throws NoSuchMethodException {
+		Method method = TestTemplate_MultipleProduces.class.getDeclaredMethod("multipleProduces");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().headers().get("Accept")).containsExactly("application/jose, application/json");
+	}
+
+	@Test
+	void testSingleProducesValueUnchanged() throws NoSuchMethodException {
+		Method method = TestTemplate_MultipleProduces.class.getDeclaredMethod("singleProduces");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().headers().get("Accept")).containsExactly(MediaType.APPLICATION_JSON_VALUE);
+	}
+
+	@Test
+	void testEmptyProducesNoAcceptHeader() throws NoSuchMethodException {
+		Method method = TestTemplate_MultipleProduces.class.getDeclaredMethod("noProduces");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().headers().get("Accept")).isNull();
+	}
+
+	@Test
+	void testProducesWithBlankEntryIgnored() throws NoSuchMethodException {
+		Method method = TestTemplate_MultipleProduces.class.getDeclaredMethod("producesWithBlankEntry");
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().headers().get("Accept")).containsExactly("application/jose, application/json");
+	}
+
+	@Test
 	void testMultipleRequestPartAnnotations() throws NoSuchMethodException {
 		Method method = TestTemplate_RequestPart.class.getDeclaredMethod("requestWithMultipleParts",
 				MultipartFile.class, String.class);
@@ -1138,6 +1170,22 @@ class SpringMvcContractTests {
 		public String toString() {
 			return "TestObject{" + "something='" + something + "', " + "number=" + number + "}";
 		}
+
+	}
+
+	public interface TestTemplate_MultipleProduces {
+
+		@GetMapping(value = "/test", produces = { "application/jose", "application/json" })
+		ResponseEntity<TestObject> multipleProduces();
+
+		@GetMapping(value = "/test", produces = MediaType.APPLICATION_JSON_VALUE)
+		ResponseEntity<TestObject> singleProduces();
+
+		@GetMapping("/test")
+		ResponseEntity<TestObject> noProduces();
+
+		@GetMapping(value = "/test", produces = { "application/jose", "", "application/json" })
+		ResponseEntity<TestObject> producesWithBlankEntry();
 
 	}
 


### PR DESCRIPTION
`SpringMvcContract.parseProduces()` only used the first element of `produces`, silently dropping additional media types from the `Accept` header.

```java
@GetMapping(value = "/payments/{id}", produces = {"application/jose", "application/json"})
```
**Before**: `Accept: application/jose`
**After**: `Accept: application/jose, application/json`

Fixes gh-916