### PR TITLE
[Docs] Document limitation of @Cacheable(sync=true) with Feign

### DIFF
--- a/docs/modules/ROOT/pages/spring-cloud-openfeign.adoc
+++ b/docs/modules/ROOT/pages/spring-cloud-openfeign.adoc
@@ -879,6 +879,46 @@ protected interface DemoFeignClient {
 }
 ----
 
+
+=== FeignClientBuilder
+
+`FeignClientBuilder` allows programmatic creation of Feign clients without using the `@FeignClient` annotation.
+
+It builds clients in the same way as `@FeignClient`, but provides flexibility for dynamic use cases.
+
+Unlike `@FeignClient`, which defines clients statically, `FeignClientBuilder` allows creating clients dynamically at runtime.
+
+==== Basic Usage
+
+[source,java,indent=0]
+----
+@Autowired
+private ApplicationContext applicationContext;
+
+FeignClientBuilder builder = new FeignClientBuilder(applicationContext);
+
+MyClient client = builder
+    .forType(MyClient.class, "myClient")
+    .url("http://localhost:8080")
+    .build();
+----
+
+==== Configuration Options
+
+* `url(String url)` - Sets the target URL
+* `path(String path)` - Adds a base path
+* `contextId(String contextId)` - Unique identifier
+* `dismiss404(boolean)` - Ignore 404 errors
+* `inheritParentContext(boolean)` - Inherit parent config
+* `fallback(Class<? extends T>)` - Fallback class
+* `customize(FeignBuilderCustomizer)` - Customize Feign builder
+
+==== When to Use
+
+* Dynamic client creation
+* Runtime configuration
+* When `@FeignClient` is not sufficient
+
 [[reactive-support]]
 === Reactive Support
 As at the time of active development of Spring Cloud OpenFeign, the https://github.com/OpenFeign/feign[OpenFeign project] did not support reactive clients, such as https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/web/reactive/function/client/WebClient.html[Spring WebClient], such support could not be added to Spring Cloud OpenFeign either.
@@ -893,6 +933,7 @@ We discourage using Feign clients in the early stages of application lifecycle, 
 Similarly, depending on how you are using your Feign clients, you may see initialization errors when starting your application. To work around this problem you can use an `ObjectProvider` when autowiring your client.
 
 [source,java,indent=0]
+
 ----
 @Autowired
 ObjectProvider<TestFeignClient> testFeignClient;


### PR DESCRIPTION
This PR documents a limitation when using @Cacheable(sync = true) with Feign clients.

- Explains the issue (recursive cache invocation)
- Mentions resulting IllegalStateException
- Provides workaround (disable sync or Feign caching)

Closes #659