### PR TITLE
Fix issue #1204

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/encoding/FeignAcceptGzipEncodingAutoConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/encoding/FeignAcceptGzipEncodingAutoConfiguration.java
@@ -16,11 +16,9 @@
 
 package org.springframework.cloud.openfeign.encoding;
 
-import feign.Client;
 import feign.Feign;
 
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -39,7 +37,6 @@ import org.springframework.context.annotation.Configuration;
 @Configuration(proxyBeanMethods = false)
 @EnableConfigurationProperties(FeignClientEncodingProperties.class)
 @ConditionalOnClass(Feign.class)
-@ConditionalOnBean(Client.class)
 @ConditionalOnProperty("spring.cloud.openfeign.compression.response.enabled")
 // The OK HTTP client uses "transparent" compression.
 // If the accept-encoding header is present, it disables transparent compression.

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignCompressionTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignCompressionTests.java
@@ -77,7 +77,8 @@ class FeignCompressionTests {
 	@Test
 	void shouldAddResponseCompressionInterceptorWithoutClientBean() {
 		new ApplicationContextRunner()
-			.withPropertyValues("spring.cloud.openfeign.compression.response.enabled=true")
+			.withPropertyValues("spring.cloud.openfeign.compression.response.enabled=true",
+					"spring.cloud.openfeign.okhttp.enabled=false")
 			.withConfiguration(AutoConfigurations.of(FeignAutoConfiguration.class,
 					FeignAcceptGzipEncodingAutoConfiguration.class))
 			.run(context -> {

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignCompressionTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignCompressionTests.java
@@ -74,6 +74,17 @@ class FeignCompressionTests {
 			});
 	}
 
+	@Test
+	void shouldAddResponseCompressionInterceptorWithoutClientBean() {
+		new ApplicationContextRunner()
+			.withPropertyValues("spring.cloud.openfeign.compression.response.enabled=true")
+			.withConfiguration(AutoConfigurations.of(FeignAutoConfiguration.class,
+					FeignAcceptGzipEncodingAutoConfiguration.class))
+			.run(context -> {
+				assertThat(context).hasSingleBean(FeignAcceptGzipEncodingInterceptor.class);
+			});
+	}
+
 	@Configuration
 	static class OkHttpClientConfiguration {
 


### PR DESCRIPTION
Close https://github.com/spring-cloud/spring-cloud-openfeign/issues/1204.

Remove @ConditionalOnBean(Client.class) from FeignAcceptGzipEncodingAutoConfiguration FeignAcceptGzipEncodingAutoConfiguration requires a feign.Client bean in the main context to activate. When no explicit Client bean is registered (e.g., no load balancer on classpath), response compression is silently skipped even with compression.response.enabled=true.

FeignAcceptGzipEncodingInterceptor is a RequestInterceptor that only adds an Accept-Encoding header — it has no dependency on Client. Removing this condition makes it consistent with FeignContentGzipEncodingAutoConfiguration, which never had this restriction.

All Feign client implementations (JDK HttpURLConnection, Apache HC5, Java HttpClient) handle gzip decompression transparently, so there is no risk.