### PR TITLE
Fix unconditional overwrite of resolved fallbackFactory in FeignClientsRegistrar

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java
@@ -241,7 +241,6 @@ class FeignClientsRegistrar implements ImportBeanDefinitionRegistrar, ResourceLo
 			definition.addPropertyValue("fallbackFactory", fallbackFactory instanceof Class ? fallbackFactory
 					: ClassUtils.resolveClassName(fallbackFactory.toString(), null));
 		}
-		definition.addPropertyValue("fallbackFactory", attributes.get("fallbackFactory"));
 		definition.setAutowireMode(AbstractBeanDefinition.AUTOWIRE_BY_TYPE);
 		definition.addPropertyValue("refreshableClient", isClientRefreshEnabled());
 		String[] qualifiers = getQualifiers(attributes);


### PR DESCRIPTION
Fixes gh-1367

## Summary

`FeignClientsRegistrar.eagerlyRegisterFeignClientBeanDefinition` resolves the `fallbackFactory` attribute via `ClassUtils.resolveClassName(...)` when it is supplied as a `String`, but the very next line unconditionally re-sets the same property to the raw attribute value, discarding the resolved `Class` and rendering the resolution dead code:

https://github.com/spring-cloud/spring-cloud-openfeign/blob/main/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsRegistrar.java#L239-L244

```java
Object fallbackFactory = attributes.get(\"fallbackFactory\");
if (fallbackFactory != null) {
    definition.addPropertyValue(\"fallbackFactory\", fallbackFactory instanceof Class ? fallbackFactory
            : ClassUtils.resolveClassName(fallbackFactory.toString(), null));
}
definition.addPropertyValue(\"fallbackFactory\", attributes.get(\"fallbackFactory\")); // unconditional overwrite
```

The duplicate, unconditional `addPropertyValue` mirrors a pattern that the same method already gets right for `fallback` (lines 234-238 — single conditional set, no overwrite) and that the lazy registration path also gets right (`lazilyRegisterFeignClientBeanDefinition`, lines 288-292). It looks unintentional.

## Change

Remove the duplicate line so the resolved value survives.

## Test plan

- [x] `./mvnw -pl spring-cloud-openfeign-core -am test -Dtest=FeignClientsRegistrarTests` — 15 tests, 0 failures, 0 errors, 1 skipped (existing `testFallback` and `testFallbackFactory` still pass with the `Class<?>` annotation path).