### PR TITLE
test: fix self-comparison in SpringMvcContractTests

### DIFF
--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
@@ -316,8 +316,7 @@ class SpringMvcContractTests {
 
 		assertThat(data.template().url()).isEqualTo(extendedData.template().url());
 		assertThat(data.template().method()).isEqualTo(extendedData.template().method());
-		assertThat(data.indexToName().get(0).iterator().next()).isEqualTo(data.indexToName().get(0).iterator().next());
-		assertThat(data.indexToName().get(0).iterator().next()).isEqualTo(data.indexToName().get(0).iterator().next());
+		assertThat(data.indexToName()).containsExactlyEntriesOf(extendedData.indexToName());
 		assertThat(data.template().decodeSlash()).isTrue();
 	}
 


### PR DESCRIPTION
## Summary

This PR fixes self-comparing assertions in `SpringMvcContractTests`.

The affected assertions compared `data.indexToName()` with itself, which means they would always pass and would not verify the metadata produced for the extended interface case.

The updated assertion compares `data.indexToName()` against `extendedData.indexToName()`, matching the intent of the surrounding assertions that already compare the generated URL and HTTP method.

## Testing

Ran:

```bash
./mvnw -pl spring-cloud-openfeign-core -Dtest=SpringMvcContractTests test