### PR TITLE
Fix circuit breaker Feign builder direct usage

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
@@ -184,6 +184,11 @@ public class FeignAutoConfiguration {
 			return new AlphanumericCircuitBreakerNameResolver();
 		}
 
+		/**
+		 * @deprecated in favor of
+		 * {@link #circuitBreakerFeignTargeter(CircuitBreakerFactory, FeignCircuitBreakerProperties, CircuitBreakerNameResolver)}.
+		 */
+		@Deprecated
 		@SuppressWarnings("rawtypes")
 		public Targeter circuitBreakerFeignTargeter(CircuitBreakerFactory circuitBreakerFactory,
 				@Value("${spring.cloud.openfeign.circuitbreaker.group.enabled:false}") boolean circuitBreakerGroupEnabled,

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
@@ -37,6 +37,7 @@ import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -184,14 +185,22 @@ public class FeignAutoConfiguration {
 		}
 
 		@SuppressWarnings("rawtypes")
+		public Targeter circuitBreakerFeignTargeter(CircuitBreakerFactory circuitBreakerFactory,
+				@Value("${spring.cloud.openfeign.circuitbreaker.group.enabled:false}") boolean circuitBreakerGroupEnabled,
+				CircuitBreakerNameResolver circuitBreakerNameResolver) {
+			return new FeignCircuitBreakerTargeter(circuitBreakerFactory, circuitBreakerGroupEnabled,
+					circuitBreakerNameResolver);
+		}
+
+		@SuppressWarnings("rawtypes")
 		@Bean
 		@ConditionalOnMissingBean
 		@ConditionalOnBean(CircuitBreakerFactory.class)
 		public Targeter circuitBreakerFeignTargeter(CircuitBreakerFactory circuitBreakerFactory,
 				FeignCircuitBreakerProperties circuitBreakerProperties,
 				CircuitBreakerNameResolver circuitBreakerNameResolver) {
-			return new FeignCircuitBreakerTargeter(circuitBreakerFactory,
-					circuitBreakerProperties.getGroup().isEnabled(), circuitBreakerNameResolver);
+			return circuitBreakerFeignTargeter(circuitBreakerFactory, circuitBreakerProperties.getGroup().isEnabled(),
+					circuitBreakerNameResolver);
 		}
 
 		static class DefaultCircuitBreakerNameResolver implements CircuitBreakerNameResolver {

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
@@ -37,7 +37,6 @@ import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -86,7 +85,7 @@ import org.springframework.util.ClassUtils;
 @Configuration(proxyBeanMethods = false)
 @ConditionalOnClass(Feign.class)
 @EnableConfigurationProperties({ FeignClientProperties.class, FeignHttpClientProperties.class,
-		FeignEncoderProperties.class, FeignOAuth2Properties.class })
+		FeignEncoderProperties.class, FeignOAuth2Properties.class, FeignCircuitBreakerProperties.class })
 public class FeignAutoConfiguration {
 
 	private static final Log LOG = LogFactory.getLog(FeignAutoConfiguration.class);
@@ -189,10 +188,10 @@ public class FeignAutoConfiguration {
 		@ConditionalOnMissingBean
 		@ConditionalOnBean(CircuitBreakerFactory.class)
 		public Targeter circuitBreakerFeignTargeter(CircuitBreakerFactory circuitBreakerFactory,
-				@Value("${spring.cloud.openfeign.circuitbreaker.group.enabled:false}") boolean circuitBreakerGroupEnabled,
+				FeignCircuitBreakerProperties circuitBreakerProperties,
 				CircuitBreakerNameResolver circuitBreakerNameResolver) {
-			return new FeignCircuitBreakerTargeter(circuitBreakerFactory, circuitBreakerGroupEnabled,
-					circuitBreakerNameResolver);
+			return new FeignCircuitBreakerTargeter(circuitBreakerFactory,
+					circuitBreakerProperties.getGroup().isEnabled(), circuitBreakerNameResolver);
 		}
 
 		static class DefaultCircuitBreakerNameResolver implements CircuitBreakerNameResolver {

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignCircuitBreakerInvocationHandler.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignCircuitBreakerInvocationHandler.java
@@ -95,9 +95,11 @@ class FeignCircuitBreakerInvocationHandler implements InvocationHandler {
 			return toString();
 		}
 
-		String circuitName = circuitBreakerNameResolver.resolveCircuitBreakerName(feignClientName, target, method);
-		CircuitBreaker circuitBreaker = circuitBreakerGroupEnabled ? factory.create(circuitName, feignClientName)
-				: factory.create(circuitName);
+		String resolvedFeignClientName = feignClientName != null ? feignClientName : target.name();
+		String circuitName = circuitBreakerNameResolver.resolveCircuitBreakerName(resolvedFeignClientName, target,
+				method);
+		CircuitBreaker circuitBreaker = circuitBreakerGroupEnabled
+				? factory.create(circuitName, resolvedFeignClientName) : factory.create(circuitName);
 		Supplier<Object> supplier = asSupplier(method, args);
 		if (this.nullableFallbackFactory != null) {
 			Function<Throwable, Object> fallbackFunction = throwable -> {

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignCircuitBreakerProperties.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignCircuitBreakerProperties.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2013-present the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cloud.openfeign;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Configuration properties for Feign circuit breaker support.
+ */
+@ConfigurationProperties("spring.cloud.openfeign.circuitbreaker")
+public class FeignCircuitBreakerProperties {
+
+	private Group group = new Group();
+
+	private AlphanumericIds alphanumericIds = new AlphanumericIds();
+
+	public Group getGroup() {
+		return group;
+	}
+
+	public void setGroup(Group group) {
+		this.group = group;
+	}
+
+	public AlphanumericIds getAlphanumericIds() {
+		return alphanumericIds;
+	}
+
+	public void setAlphanumericIds(AlphanumericIds alphanumericIds) {
+		this.alphanumericIds = alphanumericIds;
+	}
+
+	public static class Group {
+
+		private boolean enabled;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+	}
+
+	public static class AlphanumericIds {
+
+		private boolean enabled = true;
+
+		public boolean isEnabled() {
+			return enabled;
+		}
+
+		public void setEnabled(boolean enabled) {
+			this.enabled = enabled;
+		}
+
+	}
+
+}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -36,6 +36,7 @@ import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -248,8 +249,14 @@ public class FeignClientsConfiguration {
 		@Scope("prototype")
 		@ConditionalOnMissingBean
 		@ConditionalOnBean(CircuitBreakerFactory.class)
-		public Feign.Builder circuitBreakerFeignBuilder() {
-			return FeignCircuitBreaker.builder();
+		public Feign.Builder circuitBreakerFeignBuilder(CircuitBreakerFactory circuitBreakerFactory,
+				@Value("${spring.cloud.openfeign.circuitbreaker.group.enabled:false}") boolean circuitBreakerGroupEnabled,
+				ObjectProvider<CircuitBreakerNameResolver> circuitBreakerNameResolver) {
+			return FeignCircuitBreaker.builder()
+				.circuitBreakerFactory(circuitBreakerFactory)
+				.circuitBreakerGroupEnabled(circuitBreakerGroupEnabled)
+				.circuitBreakerNameResolver(circuitBreakerNameResolver
+					.getIfAvailable(() -> (feignClientName, target, method) -> Feign.configKey(target.type(), method)));
 		}
 
 	}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -46,6 +46,8 @@ import org.springframework.boot.data.autoconfigure.web.DataWebProperties;
 import org.springframework.boot.http.converter.autoconfigure.ClientHttpMessageConvertersCustomizer;
 import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
 import org.springframework.cloud.client.circuitbreaker.CircuitBreakerFactory;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration.CircuitBreakerPresentFeignTargeterConfiguration.AlphanumericCircuitBreakerNameResolver;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration.CircuitBreakerPresentFeignTargeterConfiguration.DefaultCircuitBreakerNameResolver;
 import org.springframework.cloud.openfeign.clientconfig.FeignClientConfigurer;
 import org.springframework.cloud.openfeign.support.AbstractFormWriter;
 import org.springframework.cloud.openfeign.support.FeignEncoderProperties;
@@ -251,12 +253,20 @@ public class FeignClientsConfiguration {
 		@ConditionalOnBean(CircuitBreakerFactory.class)
 		public Feign.Builder circuitBreakerFeignBuilder(CircuitBreakerFactory circuitBreakerFactory,
 				@Value("${spring.cloud.openfeign.circuitbreaker.group.enabled:false}") boolean circuitBreakerGroupEnabled,
+				@Value("${spring.cloud.openfeign.circuitbreaker.alphanumeric-ids.enabled:true}") boolean alphanumericIdsEnabled,
 				ObjectProvider<CircuitBreakerNameResolver> circuitBreakerNameResolver) {
 			return FeignCircuitBreaker.builder()
 				.circuitBreakerFactory(circuitBreakerFactory)
 				.circuitBreakerGroupEnabled(circuitBreakerGroupEnabled)
 				.circuitBreakerNameResolver(circuitBreakerNameResolver
-					.getIfAvailable(() -> (feignClientName, target, method) -> Feign.configKey(target.type(), method)));
+					.getIfAvailable(() -> defaultCircuitBreakerNameResolver(alphanumericIdsEnabled)));
+		}
+
+		private CircuitBreakerNameResolver defaultCircuitBreakerNameResolver(boolean alphanumericIdsEnabled) {
+			if (alphanumericIdsEnabled) {
+				return new AlphanumericCircuitBreakerNameResolver();
+			}
+			return new DefaultCircuitBreakerNameResolver();
 		}
 
 	}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -240,6 +240,18 @@ public class FeignClientsConfiguration {
 	@ConditionalOnProperty("spring.cloud.openfeign.circuitbreaker.enabled")
 	protected static class CircuitBreakerPresentFeignBuilderConfiguration {
 
+		@Autowired
+		private CircuitBreakerFactory circuitBreakerFactory;
+
+		@Value("${spring.cloud.openfeign.circuitbreaker.group.enabled:false}")
+		private boolean circuitBreakerGroupEnabled;
+
+		@Value("${spring.cloud.openfeign.circuitbreaker.alphanumeric-ids.enabled:true}")
+		private boolean alphanumericIdsEnabled;
+
+		@Autowired
+		private ObjectProvider<CircuitBreakerNameResolver> circuitBreakerNameResolver;
+
 		@Bean
 		@Scope("prototype")
 		@ConditionalOnMissingBean({ Feign.Builder.class, CircuitBreakerFactory.class })
@@ -251,9 +263,13 @@ public class FeignClientsConfiguration {
 		@Scope("prototype")
 		@ConditionalOnMissingBean
 		@ConditionalOnBean(CircuitBreakerFactory.class)
+		public Feign.Builder circuitBreakerFeignBuilder() {
+			return circuitBreakerFeignBuilder(circuitBreakerFactory, circuitBreakerGroupEnabled, alphanumericIdsEnabled,
+					circuitBreakerNameResolver);
+		}
+
 		public Feign.Builder circuitBreakerFeignBuilder(CircuitBreakerFactory circuitBreakerFactory,
-				@Value("${spring.cloud.openfeign.circuitbreaker.group.enabled:false}") boolean circuitBreakerGroupEnabled,
-				@Value("${spring.cloud.openfeign.circuitbreaker.alphanumeric-ids.enabled:true}") boolean alphanumericIdsEnabled,
+				boolean circuitBreakerGroupEnabled, boolean alphanumericIdsEnabled,
 				ObjectProvider<CircuitBreakerNameResolver> circuitBreakerNameResolver) {
 			return FeignCircuitBreaker.builder()
 				.circuitBreakerFactory(circuitBreakerFactory)

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -246,6 +246,11 @@ public class FeignClientsConfiguration {
 			return Feign.builder().retryer(retryer);
 		}
 
+		/**
+		 * @deprecated in favor of
+		 * {@link #circuitBreakerFeignBuilder(CircuitBreakerFactory, FeignCircuitBreakerProperties, ObjectProvider)}.
+		 */
+		@Deprecated
 		public Feign.Builder circuitBreakerFeignBuilder() {
 			return FeignCircuitBreaker.builder();
 		}

--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignClientsConfiguration.java
@@ -36,7 +36,6 @@ import io.micrometer.observation.ObservationRegistry;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
@@ -240,18 +239,6 @@ public class FeignClientsConfiguration {
 	@ConditionalOnProperty("spring.cloud.openfeign.circuitbreaker.enabled")
 	protected static class CircuitBreakerPresentFeignBuilderConfiguration {
 
-		@Autowired
-		private CircuitBreakerFactory circuitBreakerFactory;
-
-		@Value("${spring.cloud.openfeign.circuitbreaker.group.enabled:false}")
-		private boolean circuitBreakerGroupEnabled;
-
-		@Value("${spring.cloud.openfeign.circuitbreaker.alphanumeric-ids.enabled:true}")
-		private boolean alphanumericIdsEnabled;
-
-		@Autowired
-		private ObjectProvider<CircuitBreakerNameResolver> circuitBreakerNameResolver;
-
 		@Bean
 		@Scope("prototype")
 		@ConditionalOnMissingBean({ Feign.Builder.class, CircuitBreakerFactory.class })
@@ -259,27 +246,27 @@ public class FeignClientsConfiguration {
 			return Feign.builder().retryer(retryer);
 		}
 
+		public Feign.Builder circuitBreakerFeignBuilder() {
+			return FeignCircuitBreaker.builder();
+		}
+
 		@Bean
 		@Scope("prototype")
 		@ConditionalOnMissingBean
 		@ConditionalOnBean(CircuitBreakerFactory.class)
-		public Feign.Builder circuitBreakerFeignBuilder() {
-			return circuitBreakerFeignBuilder(circuitBreakerFactory, circuitBreakerGroupEnabled, alphanumericIdsEnabled,
-					circuitBreakerNameResolver);
-		}
-
 		public Feign.Builder circuitBreakerFeignBuilder(CircuitBreakerFactory circuitBreakerFactory,
-				boolean circuitBreakerGroupEnabled, boolean alphanumericIdsEnabled,
+				FeignCircuitBreakerProperties circuitBreakerProperties,
 				ObjectProvider<CircuitBreakerNameResolver> circuitBreakerNameResolver) {
 			return FeignCircuitBreaker.builder()
 				.circuitBreakerFactory(circuitBreakerFactory)
-				.circuitBreakerGroupEnabled(circuitBreakerGroupEnabled)
+				.circuitBreakerGroupEnabled(circuitBreakerProperties.getGroup().isEnabled())
 				.circuitBreakerNameResolver(circuitBreakerNameResolver
-					.getIfAvailable(() -> defaultCircuitBreakerNameResolver(alphanumericIdsEnabled)));
+					.getIfAvailable(() -> defaultCircuitBreakerNameResolver(circuitBreakerProperties)));
 		}
 
-		private CircuitBreakerNameResolver defaultCircuitBreakerNameResolver(boolean alphanumericIdsEnabled) {
-			if (alphanumericIdsEnabled) {
+		private CircuitBreakerNameResolver defaultCircuitBreakerNameResolver(
+				FeignCircuitBreakerProperties circuitBreakerProperties) {
+			if (circuitBreakerProperties.getAlphanumericIds().isEnabled()) {
 				return new AlphanumericCircuitBreakerNameResolver();
 			}
 			return new DefaultCircuitBreakerNameResolver();

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
@@ -32,10 +32,12 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
 import org.springframework.cloud.client.circuitbreaker.CircuitBreakerFactory;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration.CircuitBreakerPresentFeignTargeterConfiguration.AlphanumericCircuitBreakerNameResolver;
+import org.springframework.cloud.openfeign.FeignAutoConfiguration.CircuitBreakerPresentFeignTargeterConfiguration.DefaultCircuitBreakerNameResolver;
 import org.springframework.cloud.openfeign.security.OAuth2AccessTokenInterceptor;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -120,7 +122,7 @@ class FeignAutoConfigurationTests {
 	}
 
 	@Test
-	void shouldConfigureCircuitBreakerFeignBuilderWithoutNameResolverBean() {
+	void shouldConfigureCircuitBreakerFeignBuilderWithoutNameResolverBean() throws NoSuchMethodException {
 		CircuitBreakerFactory<?, ?> circuitBreakerFactory = mock(CircuitBreakerFactory.class);
 		new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(FeignClientsConfiguration.class))
 			.withPropertyValues("spring.cloud.openfeign.circuitbreaker.enabled=true",
@@ -128,10 +130,45 @@ class FeignAutoConfigurationTests {
 			.withBean(CircuitBreakerFactory.class, () -> circuitBreakerFactory)
 			.run(ctx -> {
 				Feign.Builder builder = ctx.getBean(Feign.Builder.class);
+				CircuitBreakerNameResolver circuitBreakerNameResolver = (CircuitBreakerNameResolver) ReflectionTestUtils
+					.getField(builder, "circuitBreakerNameResolver");
+				Method method = DirectCircuitBreakerClient.class.getMethod("get");
+				Target<DirectCircuitBreakerClient> target = new Target.HardCodedTarget<>(
+						DirectCircuitBreakerClient.class, "directClient", "http://localhost");
 
 				assertThat(builder).isInstanceOf(FeignCircuitBreaker.Builder.class)
 					.hasFieldOrPropertyWithValue("circuitBreakerFactory", circuitBreakerFactory)
-					.hasFieldOrProperty("circuitBreakerNameResolver");
+					.hasFieldOrPropertyWithValue("circuitBreakerNameResolver", circuitBreakerNameResolver);
+				assertThat(circuitBreakerNameResolver)
+					.isExactlyInstanceOf(AlphanumericCircuitBreakerNameResolver.class);
+				assertThat(circuitBreakerNameResolver.resolveCircuitBreakerName("directClient", target, method))
+					.isEqualTo(Feign.configKey(target.type(), method).replaceAll("[^a-zA-Z0-9]", ""));
+			});
+	}
+
+	@Test
+	void shouldConfigureDefaultCircuitBreakerFeignBuilderNameResolverWhenAlphanumericIdsDisabled()
+			throws NoSuchMethodException {
+		CircuitBreakerFactory<?, ?> circuitBreakerFactory = mock(CircuitBreakerFactory.class);
+		new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(FeignClientsConfiguration.class))
+			.withPropertyValues("spring.cloud.openfeign.circuitbreaker.enabled=true",
+					"spring.cloud.openfeign.circuitbreaker.alphanumeric-ids.enabled=false",
+					"spring.cloud.openfeign.httpclient.hc5.enabled=false")
+			.withBean(CircuitBreakerFactory.class, () -> circuitBreakerFactory)
+			.run(ctx -> {
+				Feign.Builder builder = ctx.getBean(Feign.Builder.class);
+				CircuitBreakerNameResolver circuitBreakerNameResolver = (CircuitBreakerNameResolver) ReflectionTestUtils
+					.getField(builder, "circuitBreakerNameResolver");
+				Method method = DirectCircuitBreakerClient.class.getMethod("get");
+				Target<DirectCircuitBreakerClient> target = new Target.HardCodedTarget<>(
+						DirectCircuitBreakerClient.class, "directClient", "http://localhost");
+
+				assertThat(builder).isInstanceOf(FeignCircuitBreaker.Builder.class)
+					.hasFieldOrPropertyWithValue("circuitBreakerFactory", circuitBreakerFactory)
+					.hasFieldOrPropertyWithValue("circuitBreakerNameResolver", circuitBreakerNameResolver);
+				assertThat(circuitBreakerNameResolver).isExactlyInstanceOf(DefaultCircuitBreakerNameResolver.class);
+				assertThat(circuitBreakerNameResolver.resolveCircuitBreakerName("directClient", target, method))
+					.isEqualTo(Feign.configKey(target.type(), method));
 			});
 	}
 

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
@@ -17,7 +17,11 @@
 package org.springframework.cloud.openfeign;
 
 import java.lang.reflect.Method;
+import java.util.Map;
+import java.util.function.Supplier;
 
+import feign.Feign;
+import feign.InvocationHandlerFactory;
 import feign.Target;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
@@ -25,6 +29,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
 import org.springframework.cloud.client.circuitbreaker.CircuitBreakerFactory;
 import org.springframework.cloud.openfeign.FeignAutoConfiguration.CircuitBreakerPresentFeignTargeterConfiguration.AlphanumericCircuitBreakerNameResolver;
 import org.springframework.cloud.openfeign.security.OAuth2AccessTokenInterceptor;
@@ -33,7 +38,10 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Tim Peeters
@@ -92,6 +100,63 @@ class FeignAutoConfigurationTests {
 	}
 
 	@Test
+	void shouldConfigureCircuitBreakerFeignBuilderWhenUsedDirectly() {
+		CircuitBreakerFactory<?, ?> circuitBreakerFactory = mock(CircuitBreakerFactory.class);
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(FeignAutoConfiguration.class, FeignClientsConfiguration.class))
+			.withPropertyValues("spring.cloud.openfeign.circuitbreaker.enabled=true",
+					"spring.cloud.openfeign.circuitbreaker.group.enabled=true",
+					"spring.cloud.openfeign.httpclient.hc5.enabled=false")
+			.withBean(CircuitBreakerFactory.class, () -> circuitBreakerFactory)
+			.run(ctx -> {
+				CircuitBreakerNameResolver circuitBreakerNameResolver = ctx.getBean(CircuitBreakerNameResolver.class);
+				Feign.Builder builder = ctx.getBean(Feign.Builder.class);
+
+				assertThat(builder).isInstanceOf(FeignCircuitBreaker.Builder.class)
+					.hasFieldOrPropertyWithValue("circuitBreakerFactory", circuitBreakerFactory)
+					.hasFieldOrPropertyWithValue("circuitBreakerGroupEnabled", true)
+					.hasFieldOrPropertyWithValue("circuitBreakerNameResolver", circuitBreakerNameResolver);
+			});
+	}
+
+	@Test
+	void shouldConfigureCircuitBreakerFeignBuilderWithoutNameResolverBean() {
+		CircuitBreakerFactory<?, ?> circuitBreakerFactory = mock(CircuitBreakerFactory.class);
+		new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(FeignClientsConfiguration.class))
+			.withPropertyValues("spring.cloud.openfeign.circuitbreaker.enabled=true",
+					"spring.cloud.openfeign.httpclient.hc5.enabled=false")
+			.withBean(CircuitBreakerFactory.class, () -> circuitBreakerFactory)
+			.run(ctx -> {
+				Feign.Builder builder = ctx.getBean(Feign.Builder.class);
+
+				assertThat(builder).isInstanceOf(FeignCircuitBreaker.Builder.class)
+					.hasFieldOrPropertyWithValue("circuitBreakerFactory", circuitBreakerFactory)
+					.hasFieldOrProperty("circuitBreakerNameResolver");
+			});
+	}
+
+	@Test
+	void shouldUseTargetNameWhenFeignClientNameIsNotSet() throws Throwable {
+		CircuitBreakerFactory<?, ?> circuitBreakerFactory = mock(CircuitBreakerFactory.class);
+		CircuitBreaker circuitBreaker = mock(CircuitBreaker.class);
+		Method method = DirectCircuitBreakerClient.class.getMethod("get");
+		InvocationHandlerFactory.MethodHandler methodHandler = mock(InvocationHandlerFactory.MethodHandler.class);
+		Target<DirectCircuitBreakerClient> target = new Target.HardCodedTarget<>(DirectCircuitBreakerClient.class,
+				"directClient", "http://localhost");
+		FeignCircuitBreakerInvocationHandler handler = new FeignCircuitBreakerInvocationHandler(circuitBreakerFactory,
+				null, target, Map.of(method, methodHandler), null, true,
+				(feignClientName, targetType, targetMethod) -> feignClientName + "#" + targetMethod.getName());
+
+		when(circuitBreakerFactory.create("directClient#get", "directClient")).thenReturn(circuitBreaker);
+		when(circuitBreaker.run(any(Supplier.class)))
+			.thenAnswer(invocation -> invocation.<Supplier<?>>getArgument(0).get());
+		when(methodHandler.invoke(null)).thenReturn("ok");
+
+		assertThat(handler.invoke(null, method, null)).isEqualTo("ok");
+		verify(circuitBreakerFactory).create("directClient#get", "directClient");
+	}
+
+	@Test
 	void shouldInstantiateFeignOAuth2FeignRequestInterceptorWithoutInterceptors() {
 		runner
 			.withPropertyValues("spring.cloud.openfeign.oauth2.enabled=true",
@@ -145,6 +210,12 @@ class FeignAutoConfigurationTests {
 			ConfigurableApplicationContext ctx, Class<?> beanClass) {
 		final CircuitBreakerNameResolver bean = ctx.getBean(CircuitBreakerNameResolver.class);
 		assertThat(bean).isExactlyInstanceOf(beanClass);
+	}
+
+	interface DirectCircuitBreakerClient {
+
+		String get();
+
 	}
 
 	static class CustomCircuitBreakerNameResolver implements CircuitBreakerNameResolver {

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
@@ -17,6 +17,7 @@
 package org.springframework.cloud.openfeign;
 
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -99,6 +100,15 @@ class FeignAutoConfigurationTests {
 				assertThatFeignCircuitBreakerTargeterHasSameCircuitBreakerNameResolver(ctx,
 						CustomCircuitBreakerNameResolver.class);
 			});
+	}
+
+	@Test
+	void shouldKeepNoArgCircuitBreakerFeignBuilderSignature() throws NoSuchMethodException {
+		Method method = FeignClientsConfiguration.CircuitBreakerPresentFeignBuilderConfiguration.class
+			.getDeclaredMethod("circuitBreakerFeignBuilder");
+
+		assertThat(Modifier.isPublic(method.getModifiers())).isTrue();
+		assertThat(method.getReturnType()).isEqualTo(Feign.Builder.class);
 	}
 
 	@Test

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
@@ -114,6 +114,7 @@ class FeignAutoConfigurationTests {
 
 		assertThat(Modifier.isPublic(noArgMethod.getModifiers())).isTrue();
 		assertThat(noArgMethod.getReturnType()).isEqualTo(Feign.Builder.class);
+		assertThat(noArgMethod.isAnnotationPresent(Deprecated.class)).isTrue();
 		assertThat(beanMethod.isAnnotationPresent(Bean.class)).isTrue();
 	}
 
@@ -128,6 +129,7 @@ class FeignAutoConfigurationTests {
 
 		assertThat(Modifier.isPublic(existingMethod.getModifiers())).isTrue();
 		assertThat(existingMethod.getReturnType()).isEqualTo(Targeter.class);
+		assertThat(existingMethod.isAnnotationPresent(Deprecated.class)).isTrue();
 		assertThat(existingMethod.isAnnotationPresent(Bean.class)).isFalse();
 		assertThat(beanMethod.isAnnotationPresent(Bean.class)).isTrue();
 	}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
@@ -27,6 +27,7 @@ import feign.Target;
 import org.assertj.core.api.Condition;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
@@ -36,6 +37,7 @@ import org.springframework.cloud.openfeign.FeignAutoConfiguration.CircuitBreaker
 import org.springframework.cloud.openfeign.FeignAutoConfiguration.CircuitBreakerPresentFeignTargeterConfiguration.DefaultCircuitBreakerNameResolver;
 import org.springframework.cloud.openfeign.security.OAuth2AccessTokenInterceptor;
 import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -104,11 +106,15 @@ class FeignAutoConfigurationTests {
 
 	@Test
 	void shouldKeepNoArgCircuitBreakerFeignBuilderSignature() throws NoSuchMethodException {
-		Method method = FeignClientsConfiguration.CircuitBreakerPresentFeignBuilderConfiguration.class
+		Method noArgMethod = FeignClientsConfiguration.CircuitBreakerPresentFeignBuilderConfiguration.class
 			.getDeclaredMethod("circuitBreakerFeignBuilder");
+		Method beanMethod = FeignClientsConfiguration.CircuitBreakerPresentFeignBuilderConfiguration.class
+			.getDeclaredMethod("circuitBreakerFeignBuilder", CircuitBreakerFactory.class,
+					FeignCircuitBreakerProperties.class, ObjectProvider.class);
 
-		assertThat(Modifier.isPublic(method.getModifiers())).isTrue();
-		assertThat(method.getReturnType()).isEqualTo(Feign.Builder.class);
+		assertThat(Modifier.isPublic(noArgMethod.getModifiers())).isTrue();
+		assertThat(noArgMethod.getReturnType()).isEqualTo(Feign.Builder.class);
+		assertThat(beanMethod.isAnnotationPresent(Bean.class)).isTrue();
 	}
 
 	@Test
@@ -134,7 +140,8 @@ class FeignAutoConfigurationTests {
 	@Test
 	void shouldConfigureCircuitBreakerFeignBuilderWithoutNameResolverBean() throws NoSuchMethodException {
 		CircuitBreakerFactory<?, ?> circuitBreakerFactory = mock(CircuitBreakerFactory.class);
-		new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(FeignClientsConfiguration.class))
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(FeignAutoConfiguration.class, FeignClientsConfiguration.class))
 			.withPropertyValues("spring.cloud.openfeign.circuitbreaker.enabled=true",
 					"spring.cloud.openfeign.httpclient.hc5.enabled=false")
 			.withBean(CircuitBreakerFactory.class, () -> circuitBreakerFactory)
@@ -160,7 +167,8 @@ class FeignAutoConfigurationTests {
 	void shouldConfigureDefaultCircuitBreakerFeignBuilderNameResolverWhenAlphanumericIdsDisabled()
 			throws NoSuchMethodException {
 		CircuitBreakerFactory<?, ?> circuitBreakerFactory = mock(CircuitBreakerFactory.class);
-		new ApplicationContextRunner().withConfiguration(AutoConfigurations.of(FeignClientsConfiguration.class))
+		new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(FeignAutoConfiguration.class, FeignClientsConfiguration.class))
 			.withPropertyValues("spring.cloud.openfeign.circuitbreaker.enabled=true",
 					"spring.cloud.openfeign.circuitbreaker.alphanumeric-ids.enabled=false",
 					"spring.cloud.openfeign.httpclient.hc5.enabled=false")

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
@@ -118,6 +118,21 @@ class FeignAutoConfigurationTests {
 	}
 
 	@Test
+	void shouldKeepCircuitBreakerFeignTargeterSignature() throws NoSuchMethodException {
+		Method existingMethod = FeignAutoConfiguration.CircuitBreakerPresentFeignTargeterConfiguration.class
+			.getDeclaredMethod("circuitBreakerFeignTargeter", CircuitBreakerFactory.class, boolean.class,
+					CircuitBreakerNameResolver.class);
+		Method beanMethod = FeignAutoConfiguration.CircuitBreakerPresentFeignTargeterConfiguration.class
+			.getDeclaredMethod("circuitBreakerFeignTargeter", CircuitBreakerFactory.class,
+					FeignCircuitBreakerProperties.class, CircuitBreakerNameResolver.class);
+
+		assertThat(Modifier.isPublic(existingMethod.getModifiers())).isTrue();
+		assertThat(existingMethod.getReturnType()).isEqualTo(Targeter.class);
+		assertThat(existingMethod.isAnnotationPresent(Bean.class)).isFalse();
+		assertThat(beanMethod.isAnnotationPresent(Bean.class)).isTrue();
+	}
+
+	@Test
 	void shouldConfigureCircuitBreakerFeignBuilderWhenUsedDirectly() {
 		CircuitBreakerFactory<?, ?> circuitBreakerFactory = mock(CircuitBreakerFactory.class);
 		new ApplicationContextRunner()


### PR DESCRIPTION
Fixes gh-1210.

When the circuit breaker `Feign.Builder` bean is used directly, it currently gets created without the `CircuitBreakerFactory`, group setting, or `CircuitBreakerNameResolver` that the normal Feign client targeter path applies later. That makes the direct builder path fail at invocation time instead of behaving like the regular circuit breaker Feign client path.

This change configures the circuit breaker builder bean with the available factory, group flag, and resolver. It also falls back to the Feign target name when the builder is used outside the named Feign client targeter path.

Tests added for:
- direct `Feign.Builder` bean configuration with circuit breaker enabled
- fallback resolver behavior when no resolver bean is available
- using the target name when `feignClientName` is not set

Tested with:

```
./mvnw -pl spring-cloud-openfeign-core -Dtest=FeignAutoConfigurationTests test
```
