### PR TITLE
Remove 4.3.x Dependabot targets and scope Actions updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,25 +2,12 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    target-branch: "4.3.x"
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "github-actions"
-    directory: "/"
     target-branch: "main"
     schedule:
       interval: "weekly"
-  - package-ecosystem: maven
-    directory: /
-    schedule:
-      interval: daily
-    target-branch: 4.3.x
-    ignore:
-      # only upgrade patch versions for maintenance branch
-      - dependency-name: "*"
-        update-types:
-          - version-update:semver-major
-          - version-update:semver-minor
+    exclude-paths:
+      - ".github/workflows/release-train-test.yml"
+      - ".github/workflows/release-train-build.yml"
   - package-ecosystem: maven
     directory: /
     schedule:
@@ -39,11 +26,6 @@ updates:
       interval: weekly
   - package-ecosystem: npm
     target-branch: main
-    directory: /docs
-    schedule:
-      interval: weekly
-  - package-ecosystem: npm
-    target-branch: 4.3.x
     directory: /docs
     schedule:
       interval: weekly


### PR DESCRIPTION
Dependabot should no longer target the 4.3.x maintenance branch. This change removes those entries so update activity stays aligned with currently maintained branches.

## What changed
- Removed all `target-branch: 4.3.x` update entries across ecosystems (`github-actions`, `maven`, and `npm`).
- Kept the `github-actions` update on `main` and excluded:
  - `.github/workflows/release-train-test.yml`
  - `.github/workflows/release-train-build.yml`
- Left the remaining `main` and `docs-build` update configurations intact.