### PR TITLE
Fix templated Content-Type handling in SpringEncoder

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringEncoder.java
@@ -25,6 +25,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Stream;
 
@@ -94,7 +95,9 @@ public class SpringEncoder implements Encoder {
 			MediaType requestContentType = null;
 			if (contentTypes != null && !contentTypes.isEmpty()) {
 				String type = contentTypes.iterator().next();
-				requestContentType = MediaType.valueOf(type);
+				if (!type.startsWith("{") || !type.endsWith("}")) {
+					requestContentType = MediaType.valueOf(type);
+				}
 			}
 
 			if (isFormRelatedContentType(requestContentType)) {
@@ -242,7 +245,17 @@ public class SpringEncoder implements Encoder {
 		private final HttpHeaders httpHeaders;
 
 		private FeignOutputMessage(RequestTemplate request) {
-			httpHeaders = getHttpHeaders(request.headers());
+			Map<String, Collection<String>> headers = new LinkedHashMap<>(request.headers());
+			Collection<String> contentTypes = headers.get(HttpEncoding.CONTENT_TYPE);
+
+			if (contentTypes != null && !contentTypes.isEmpty()) {
+				String contentType = contentTypes.iterator().next();
+				if (contentType.startsWith("{") && contentType.endsWith("}")) {
+					headers.remove(HttpEncoding.CONTENT_TYPE);
+				}
+			}
+
+			httpHeaders = getHttpHeaders(headers);
 		}
 
 		@Override

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringEncoderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringEncoderTests.java
@@ -143,6 +143,19 @@ class SpringEncoderTests {
 	}
 
 	@Test
+	void testContentTypeTemplate() {
+		Encoder encoder = this.context.getInstance("foo", Encoder.class);
+		assertThat(encoder).isNotNull();
+
+		RequestTemplate request = new RequestTemplate();
+		request.header(CONTENT_TYPE, "{Content-Type}");
+
+		encoder.encode("hi", String.class, request);
+
+		assertThat(request.body()).isNotNull();
+	}
+
+	@Test
 	void testBinaryData() {
 		Encoder encoder = this.context.getInstance("foo", Encoder.class);
 		assertThat(encoder).isNotNull();


### PR DESCRIPTION
## Description

Fixes #116

`SpringEncoder` previously attempted to parse an unresolved templated `Content-Type` value, such as `{Content-Type}`, using `MediaType.valueOf(...)`, which resulted in an invalid media type exception.

This change handles unresolved `Content-Type` templates by skipping media type parsing and removing the unresolved template before creating the `HttpHeaders` passed to Spring's message converters.

## Changes

- Skip `MediaType` parsing for unresolved `Content-Type` templates.
- Remove unresolved `Content-Type` templates from headers passed to message converters.
- Add a regression test for encoding requests with a templated `Content-Type` header.

## Testing

- Added a regression test in `SpringEncoderTests`.
- Verified the targeted unit and integration tests.
- Ran the full build successfully:

```text
mvn clean verify