### PR TITLE
Fix Jackson auto-configuration classpath guard

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/FeignAutoConfiguration.java
@@ -31,6 +31,7 @@ import feign.hc5.ApacheHttp5Client;
 import feign.http2client.Http2Client;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import tools.jackson.databind.JacksonModule;
 
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
@@ -126,7 +127,7 @@ public class FeignAutoConfiguration {
 	}
 
 	@Configuration(proxyBeanMethods = false)
-	@ConditionalOnClass({ Module.class, Page.class, Sort.class })
+	@ConditionalOnClass({ JacksonModule.class, Page.class, Sort.class })
 	@ConditionalOnProperty(value = "spring.cloud.openfeign.autoconfiguration.jackson.enabled", havingValue = "true",
 			matchIfMissing = true)
 	protected static class FeignJacksonConfiguration {

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/FeignAutoConfigurationTests.java
@@ -29,6 +29,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.FilteredClassLoader;
 import org.springframework.boot.test.context.assertj.AssertableApplicationContext;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cloud.client.circuitbreaker.CircuitBreaker;
@@ -62,6 +63,23 @@ class FeignAutoConfigurationTests {
 	private final ApplicationContextRunner runner = new ApplicationContextRunner()
 		.withConfiguration(AutoConfigurations.of(FeignAutoConfiguration.class))
 		.withPropertyValues("spring.cloud.openfeign.httpclient.hc5.enabled=false");
+
+	@Test
+	void shouldConfigureJacksonModules() {
+		runner.run(context -> assertThat(context).hasBean("pageJacksonModule").hasBean("sortModule"));
+	}
+
+	@Test
+	void shouldNotConfigureJacksonModulesWhenJacksonDatabindIsMissing() {
+		runner.withClassLoader(new FilteredClassLoader("tools.jackson.databind"))
+			.run(context -> assertThat(context).doesNotHaveBean("pageJacksonModule").doesNotHaveBean("sortModule"));
+	}
+
+	@Test
+	void shouldNotConfigureJacksonModulesWhenSpringDataIsMissing() {
+		runner.withClassLoader(new FilteredClassLoader("org.springframework.data"))
+			.run(context -> assertThat(context).doesNotHaveBean("pageJacksonModule").doesNotHaveBean("sortModule"));
+	}
 
 	@Test
 	void shouldInstantiateDefaultTargeterWhenFeignCircuitBreakerIsDisabled() {


### PR DESCRIPTION
Fixes gh-1407

This change replaces the accidentally resolved `java.lang.Module` with Jackson 3's `JacksonModule` in the Feign Jackson classpath condition. This prevents the Page and Sort Jackson modules from being configured when Jackson databind is absent.

It adds tests covering three classpath scenarios: all required classes are present, Jackson databind is absent, and Spring Data is absent.
