### PR TITLE
Do not warn about GET parameters bound by a parameter processor

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -69,8 +69,6 @@ import org.springframework.http.InvalidMediaTypeException;
 import org.springframework.http.MediaType;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -94,6 +92,7 @@ import static org.springframework.core.annotation.AnnotatedElementUtils.findMerg
  * @author Tang Xiong
  * @author Juhyeong An
  * @author Olof Segergren
+ * @author Hyundoo Park
  */
 public class SpringMvcContract extends Contract.BaseContract implements ResourceLoaderAware {
 
@@ -229,23 +228,34 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 			return false;
 		}
 		int fromIndex = (params.length > 0 && params[0].getType() == URI.class) ? 1 : 0;
-		return !hasHttpAnnotations(method, fromIndex);
+		return !hasBoundParameters(method, fromIndex);
 	}
 
-	private boolean hasHttpAnnotations(Method method, int fromIndex) {
+	private boolean hasBoundParameters(Method method, int fromIndex) {
 		Parameter[] parameters = method.getParameters();
 		for (int i = fromIndex; i < parameters.length; i++) {
 			Parameter parameter = parameters[i];
+			if (isPageable(parameter.getType())) {
+				return true;
+			}
 			for (Annotation annotation : parameter.getAnnotations()) {
 				Class<? extends Annotation> annotationType = annotation.annotationType();
-				if (annotationType == RequestParam.class || annotationType == RequestHeader.class
-						|| annotationType == PathVariable.class || annotationType == SpringQueryMap.class
-						|| annotationType == QueryMap.class) {
+				if (annotationType == QueryMap.class || annotatedArgumentProcessors.containsKey(annotationType)) {
 					return true;
 				}
 			}
 		}
 		return false;
+	}
+
+	private boolean isPageable(Class<?> parameterType) {
+		try {
+			return Pageable.class.isAssignableFrom(parameterType);
+		}
+		catch (NoClassDefFoundError ignored) {
+			// Do nothing; added to avoid exceptions if optional dependency not present
+			return false;
+		}
 	}
 
 	@Override
@@ -326,18 +336,13 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 	protected boolean processAnnotationsOnParameter(MethodMetadata data, Annotation[] annotations, int paramIndex) {
 		boolean isHttpAnnotation = false;
 
-		try {
-			if (Pageable.class.isAssignableFrom(data.method().getParameterTypes()[paramIndex])) {
-				// do not set a Pageable as QueryMap if there's an actual QueryMap param
-				// present
-				if (!queryMapParamPresent(data)) {
-					data.queryMapIndex(paramIndex);
-					return false;
-				}
+		if (isPageable(data.method().getParameterTypes()[paramIndex])) {
+			// do not set a Pageable as QueryMap if there's an actual QueryMap param
+			// present
+			if (!queryMapParamPresent(data)) {
+				data.queryMapIndex(paramIndex);
+				return false;
 			}
-		}
-		catch (NoClassDefFoundError ignored) {
-			// Do nothing; added to avoid exceptions if optional dependency not present
 		}
 
 		AnnotatedParameterProcessor.AnnotatedParameterContext context = new SimpleAnnotatedParameterContext(data,

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
@@ -16,6 +16,11 @@
 
 package org.springframework.cloud.openfeign.support;
 
+import java.lang.annotation.Annotation;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
@@ -39,6 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.cloud.openfeign.AnnotatedParameterProcessor;
 import org.springframework.cloud.openfeign.CollectionFormat;
 import org.springframework.cloud.openfeign.FeignClientProperties;
 import org.springframework.cloud.openfeign.SpringQueryMap;
@@ -90,6 +96,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * @author Sam Kruglov
  * @author Bhavya Agrawal
  * @author Tang Xiong
+ * @author Hyundoo Park
  **/
 
 @ExtendWith(OutputCaptureExtension.class)
@@ -254,6 +261,45 @@ class SpringMvcContractTests {
 	@Test
 	void getWithUriAndAnnotatedParameterShouldNotWarn(CapturedOutput output) throws Exception {
 		Method method = GetWithUriAndAnnotatedParam.class.getDeclaredMethod("getValue", URI.class, String.class);
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().method()).isEqualTo("GET");
+		assertThat(output).doesNotContain("OpenFeign Warning");
+	}
+
+	@Test
+	void getWithPageableParameterShouldNotWarn(CapturedOutput output) throws Exception {
+		Method method = GetWithPageableParam.class.getDeclaredMethod("getStores", Pageable.class);
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().method()).isEqualTo("GET");
+		assertThat(data.queryMapIndex()).isZero();
+		assertThat(output).doesNotContain("OpenFeign Warning");
+	}
+
+	@Test
+	void getWithCookieValueParameterShouldNotWarn(CapturedOutput output) throws Exception {
+		Method method = GetWithCookieValueParam.class.getDeclaredMethod("getValue", String.class);
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().method()).isEqualTo("GET");
+		assertThat(output).doesNotContain("OpenFeign Warning");
+	}
+
+	@Test
+	void getWithMatrixVariableParameterShouldNotWarn(CapturedOutput output) throws Exception {
+		Method method = GetWithMatrixVariableParam.class.getDeclaredMethod("getValue", Map.class);
+		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+		assertThat(data.template().method()).isEqualTo("GET");
+		assertThat(output).doesNotContain("OpenFeign Warning");
+	}
+
+	@Test
+	void getWithCustomProcessorParameterShouldNotWarn(CapturedOutput output) throws Exception {
+		contract = new SpringMvcContract(Collections.singletonList(new CustomAnnotationParameterProcessor()),
+				getConversionService());
+		Method method = GetWithCustomAnnotationParam.class.getDeclaredMethod("getValue", String.class);
 		MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
 
 		assertThat(data.template().method()).isEqualTo("GET");
@@ -923,6 +969,59 @@ class SpringMvcContractTests {
 
 		@GetMapping("/sample/receive")
 		String getValue(URI baseUri, @RequestParam("id") String id);
+
+	}
+
+	interface GetWithPageableParam {
+
+		@GetMapping("/stores")
+		Page<String> getStores(Pageable pageable);
+
+	}
+
+	interface GetWithCookieValueParam {
+
+		@GetMapping("/test")
+		String getValue(@CookieValue("cookie1") String cookie1);
+
+	}
+
+	interface GetWithMatrixVariableParam {
+
+		@GetMapping("/matrixVariable/{params}")
+		String getValue(@MatrixVariable("params") Map<String, Object> params);
+
+	}
+
+	interface GetWithCustomAnnotationParam {
+
+		@GetMapping("/test")
+		String getValue(@CustomAnnotation("id") String id);
+
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.PARAMETER)
+	@interface CustomAnnotation {
+
+		String value();
+
+	}
+
+	static class CustomAnnotationParameterProcessor implements AnnotatedParameterProcessor {
+
+		@Override
+		public Class<? extends Annotation> getAnnotationType() {
+			return CustomAnnotation.class;
+		}
+
+		@Override
+		public boolean processArgument(AnnotatedParameterContext context, Annotation annotation, Method method) {
+			String name = ((CustomAnnotation) annotation).value();
+			context.setParameterName(name);
+			context.getMethodMetadata().template().query(name, "{" + name + "}");
+			return true;
+		}
 
 	}
 


### PR DESCRIPTION
`hasHttpAnnotations` tested a hardcoded list of five annotations before logging the "declared as GET with parameters, but none of the parameters are annotated" warning.

The contract binds more than those. `@MatrixVariable`, `@RequestPart` and `@CookieValue` have default processors, users can register their own, and an unannotated `Pageable` becomes the query map. None can fall back to POST, yet all warn today, including the docs' `StoreClient` example and `TestTemplate_MatrixVariable` here.

The check now looks the annotation up in `annotatedArgumentProcessors`, keeps feign's `@QueryMap` explicit as it has no processor, and adds `Pageable`, whose `NoClassDefFoundError` guard moves into `isPageable`.

`./mvnw -pl spring-cloud-openfeign-core test` passes on JDK 21; the four new tests fail without the change.
