### PR TITLE
Resolve placeholders in request media types

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/SpringMvcContract.java
@@ -93,6 +93,7 @@ import static org.springframework.core.annotation.AnnotatedElementUtils.findMerg
  * @author Juhyeong An
  * @author Olof Segergren
  * @author Hyundoo Park
+ * @author Rene Choi
  */
 public class SpringMvcContract extends Contract.BaseContract implements ResourceLoaderAware {
 
@@ -389,6 +390,7 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 
 	private void parseProduces(MethodMetadata md, RequestMapping annotation) {
 		String[] clientAccepts = Arrays.stream(annotation.produces())
+			.map(this::resolve)
 			.map(s -> emptyToNull(s))
 			.filter(Objects::nonNull)
 			.toArray(String[]::new);
@@ -399,7 +401,7 @@ public class SpringMvcContract extends Contract.BaseContract implements Resource
 
 	private void parseConsumes(MethodMetadata md, RequestMapping annotation) {
 		String[] serverConsumes = annotation.consumes();
-		String clientProduces = serverConsumes.length == 0 ? null : emptyToNull(serverConsumes[0]);
+		String clientProduces = serverConsumes.length == 0 ? null : emptyToNull(resolve(serverConsumes[0]));
 		if (clientProduces != null) {
 			md.template().header(CONTENT_TYPE, clientProduces);
 		}

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/SpringMvcContractTests.java
@@ -44,10 +44,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.cloud.openfeign.AnnotatedParameterProcessor;
 import org.springframework.cloud.openfeign.CollectionFormat;
 import org.springframework.cloud.openfeign.FeignClientProperties;
 import org.springframework.cloud.openfeign.SpringQueryMap;
+import org.springframework.context.support.GenericApplicationContext;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -97,6 +99,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
  * @author Bhavya Agrawal
  * @author Tang Xiong
  * @author Hyundoo Park
+ * @author Rene Choi
  **/
 
 @ExtendWith(OutputCaptureExtension.class)
@@ -858,6 +861,21 @@ class SpringMvcContractTests {
 	}
 
 	@Test
+	void testProducesAndConsumesPlaceholders() throws NoSuchMethodException {
+		try (GenericApplicationContext applicationContext = new GenericApplicationContext()) {
+			TestPropertyValues.of("test.produces=application/json", "test.consumes=application/xml")
+				.applyTo(applicationContext);
+			contract.setResourceLoader(applicationContext);
+
+			Method method = TestTemplate_MediaTypePlaceholders.class.getDeclaredMethod("exchange");
+			MethodMetadata data = contract.parseAndValidateMetadata(method.getDeclaringClass(), method);
+
+			assertThat(data.template().headers().get("Accept")).containsExactly("application/json");
+			assertThat(data.template().headers().get("Content-Type")).containsExactly("application/xml");
+		}
+	}
+
+	@Test
 	void testMultipleRequestPartAnnotations() throws NoSuchMethodException {
 		Method method = TestTemplate_RequestPart.class.getDeclaredMethod("requestWithMultipleParts",
 				MultipartFile.class, String.class);
@@ -1303,6 +1321,13 @@ class SpringMvcContractTests {
 
 		@GetMapping(value = "/test", produces = { "application/jose", "", "application/json" })
 		ResponseEntity<TestObject> producesWithBlankEntry();
+
+	}
+
+	public interface TestTemplate_MediaTypePlaceholders {
+
+		@PostMapping(value = "/test", produces = "${test.produces}", consumes = "${test.consumes}")
+		ResponseEntity<TestObject> exchange();
 
 	}
 


### PR DESCRIPTION
## Summary

- Resolve property placeholders in `@RequestMapping` `produces` and `consumes` values before adding the corresponding request headers.
- Add coverage for the generated `Accept` and `Content-Type` headers.

This is consistent with the existing placeholder handling for paths, headers, and parameters. On `main`, the regression test fails because the `Accept` header contains the literal `${test.produces}` value.

## Testing

- `./mvnw -pl spring-cloud-openfeign-core -Dtest=SpringMvcContractTests#testProducesAndConsumesPlaceholders test`
- `./mvnw -pl spring-cloud-openfeign-core -am verify`
