### PR TITLE
Fix HttpHeaders header-map params losing values via QueryMapEncoder

### DIFF
--- a/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
+++ b/spring-cloud-openfeign-core/src/main/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoder.java
@@ -25,10 +25,17 @@ import feign.querymap.BeanQueryMapEncoder;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpHeaders;
 
 /**
  * Provides support for encoding Pageable annotated as
- * {@link org.springframework.cloud.openfeign.SpringQueryMap}.
+ * {@link org.springframework.cloud.openfeign.SpringQueryMap}, and also serves as the
+ * default {@code QueryMapEncoder} used to resolve {@code @RequestHeader HttpHeaders}
+ * header-map parameters (see {@code RequestHeaderParameterProcessor}). Since Spring
+ * Framework 7, {@link HttpHeaders} no longer implements {@code MultiValueMap}, so without
+ * this special case it falls through to the generic bean-property reflection in
+ * {@link BeanQueryMapEncoder}, which drops the real header values and injects unrelated
+ * getter-derived entries instead.
  *
  * @author Hyeonmin Park
  * @author Yanming Zhou
@@ -88,6 +95,9 @@ public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
 			else if (object instanceof Sort sort) {
 				applySort(queryMap, sort);
 			}
+			else if (object instanceof HttpHeaders httpHeaders) {
+				httpHeaders.forEach(queryMap::put);
+			}
 			return queryMap;
 		}
 		else {
@@ -110,7 +120,7 @@ public class PageableSpringQueryMapEncoder extends BeanQueryMapEncoder {
 	}
 
 	protected boolean supports(Object object) {
-		return object instanceof Pageable || object instanceof Sort;
+		return object instanceof Pageable || object instanceof Sort || object instanceof HttpHeaders;
 	}
 
 }

--- a/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoderTests.java
+++ b/spring-cloud-openfeign-core/src/test/java/org/springframework/cloud/openfeign/support/PageableSpringQueryMapEncoderTests.java
@@ -28,6 +28,7 @@ import org.springframework.cloud.openfeign.FeignClientFactory;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
+import org.springframework.http.HttpHeaders;
 import org.springframework.test.annotation.DirtiesContext;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -119,6 +120,24 @@ class PageableSpringQueryMapEncoderTests {
 
 		Map<String, Object> map = encoder.encode(Pageable.unpaged());
 		assertThat(map).isEmpty();
+	}
+
+	@Test
+	void testHttpHeadersRequest() {
+		QueryMapEncoder encoder = this.context.getInstance("foo", QueryMapEncoder.class);
+		assertThat(encoder).isNotNull();
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.add("X-Custom-Header", "value1");
+		headers.add("X-Custom-Header", "value2");
+		headers.add(HttpHeaders.AUTHORIZATION, "Bearer token");
+
+		Map<String, Object> map = encoder.encode(headers);
+		assertThat(map).hasSize(2);
+		List<String> customHeaderValues = (List<String>) map.get("X-Custom-Header");
+		List<String> authorizationValues = (List<String>) map.get(HttpHeaders.AUTHORIZATION);
+		assertThat(customHeaderValues).containsExactly("value1", "value2");
+		assertThat(authorizationValues).containsExactly("Bearer token");
 	}
 
 }


### PR DESCRIPTION
Fixes gh-1328

## Root cause

Since Spring Framework 7, `HttpHeaders` no longer implements the `MultiValueMap` contract (only `Serializable`). A `@RequestHeader HttpHeaders` parameter is wired by `RequestHeaderParameterProcessor` as Feign's generic `headerMapIndex`. At invocation time, `feign.RequestTemplateFactoryResolver.toQueryMap()` only takes the fast `instanceof Map` path for a true `Map`; otherwise it delegates to the configured `QueryMapEncoder`. Spring Cloud OpenFeign registers `PageableSpringQueryMapEncoder` as the default `QueryMapEncoder` bean for all Feign clients, and its fallback (`BeanQueryMapEncoder`) reflects over the object's JavaBeans getter properties.

For an `HttpHeaders` instance this means every real header value is dropped, and the map is instead populated with unrelated getter-derived entries (`contentLength=-1`, `date=-1`, `accept=[]`, etc.) — reproduced locally:

```java
PageableSpringQueryMapEncoder encoder = new PageableSpringQueryMapEncoder();
HttpHeaders headers = new HttpHeaders();
headers.add("X-Custom", "val1");
headers.add(HttpHeaders.AUTHORIZATION, "Bearer tok");
encoder.encode(headers);
// => 25 getter-derived entries (contentLength=-1, date=-1, ...), the 2 real headers are gone
```

## Fix

`PageableSpringQueryMapEncoder` already special-cases `Pageable`/`Sort` instead of falling through to the generic bean-reflection encoder. This adds the same special-case for `HttpHeaders`, using its own `forEach(BiConsumer<String, List<String>>)` to build the query map directly — mirroring the pattern already established for `Pageable`/`Sort` in this class.

## Test

Added `PageableSpringQueryMapEncoderTests#testHttpHeadersRequest`, which fails against the old code (asserts a 2-entry map with the real header values) and passes with the fix. Verified locally:
- Targeted module test suite (`spring-cloud-openfeign-core`, 441 tests) passes with the change.
- `./mvnw validate` (checkstyle + spring-javaformat) passes with 0 violations.

Verification done: reproduced the exact symptom from gh-1328 locally against current `main` (confirmed `PageableSpringQueryMapEncoder` — the actual default `QueryMapEncoder` bean SCOF wires up — reflects `HttpHeaders` via `BeanQueryMapEncoder` and drops all real header values); confirmed no in-flight PR/linked branch on the issue; confirmed no AI-contribution policy restriction in CONTRIBUTING.md; new regression test fails on pre-fix code and passes post-fix; full module test suite green; checkstyle/javaformat clean.

Disclosure: this change was authored with AI assistance (Claude Code), with the root cause independently traced and verified against the current codebase and the fix manually reviewed before submission.